### PR TITLE
Add support for left/right groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: go
-go: tip
-script: go get code.google.com/p/go.tools/cmd/vet && go get github.com/cloudflare/redoctober && go test github.com/cloudflare/redoctober... && go vet github.com/cloudflare/redoctober...
+go: 1.2
+script:
+  - go get golang.org/x/tools/cmd/vet
+  - go get github.com/cloudflare/redoctober
+  - go test github.com/cloudflare/redoctober...
+  - go vet github.com/cloudflare/redoctober...
 notifications:
   email:
     recipients:
-      - albert@cloudflare.com
       - nick@cloudflare.com
-      - dane@cloudflare.com
+      - kyle@cloudflare.com
     on_success: never
     on_failure: change

--- a/core/core.go
+++ b/core/core.go
@@ -49,9 +49,11 @@ type encrypt struct {
 	Name     string
 	Password string
 
-	Minimum int
-	Owners  []string
-	Data    []byte
+	Minimum     int
+	Owners      []string
+	LeftOwners  []string
+	RightOwners []string
+	Data        []byte
 }
 
 type decrypt struct {
@@ -266,8 +268,13 @@ func Encrypt(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
+	if len(s.Owners) > 0 {
+		s.LeftOwners = s.Owners
+		s.RightOwners = s.Owners
+	}
+
 	// Encrypt file with list of owners
-	if resp, err := cryptor.Encrypt(s.Data, s.Owners, s.Minimum); err != nil {
+	if resp, err := cryptor.Encrypt(s.Data, s.LeftOwners, s.RightOwners, s.Minimum); err != nil {
 		log.Println("Error encrypting:", err)
 		return jsonStatusError(err)
 	} else {


### PR DESCRIPTION
LeftOwners and RightOwners can now be used as either disjoint
or overlapping sets of users for encrypting a message. Default
behavior is to set them to Owners given a non-empty Owners set.

One member from each group are required to decrypt the message.