### PR TITLE
Patches for Bugs & HMAC Malleability

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -94,6 +94,7 @@ type SummaryData struct {
 
 type DecryptWithDelegates struct {
 	Data      []byte
+	Secure    bool
 	Delegates []string
 }
 
@@ -299,7 +300,7 @@ func Decrypt(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	data, names, err := crypt.Decrypt(s.Data, s.Name)
+	data, names, secure, err := crypt.Decrypt(s.Data, s.Name)
 	if err != nil {
 		log.Println("Error decrypting:", err)
 		return jsonStatusError(err)
@@ -307,6 +308,7 @@ func Decrypt(jsonIn []byte) ([]byte, error) {
 
 	resp := &DecryptWithDelegates{
 		Data:      data,
+		Secure:    secure,
 		Delegates: names,
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -57,9 +57,11 @@ type EncryptRequest struct {
 	Name     string
 	Password string
 
-	Minimum int
-	Owners  []string
-	Data    []byte
+	Owners      []string
+	LeftOwners  []string
+	RightOwners []string
+
+	Data []byte
 
 	Labels []string
 }
@@ -277,8 +279,9 @@ func Encrypt(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	// Encrypt file with list of owners
-	if resp, err := crypt.Encrypt(s.Data, s.Labels, s.Owners, s.Minimum); err != nil {
+	// Encrypt file
+	access := cryptor.AccessStructure{s.Owners, s.LeftOwners, s.RightOwners}
+	if resp, err := crypt.Encrypt(s.Data, s.Labels, access); err != nil {
 		log.Println("Error encrypting:", err)
 		return jsonStatusError(err)
 	} else {

--- a/core/core.go
+++ b/core/core.go
@@ -15,6 +15,12 @@ import (
 	"github.com/cloudflare/redoctober/passvault"
 )
 
+var (
+	crypt   cryptor.Cryptor
+	records passvault.Records
+	cache   keycache.Cache
+)
+
 // Each of these structures corresponds to the JSON expected on the
 // correspondingly named URI (e.g. the delegate structure maps to the
 // JSON that should be sent on the /delegate URI and it is handled by
@@ -51,11 +57,9 @@ type EncryptRequest struct {
 	Name     string
 	Password string
 
-	Minimum     int
-	Owners      []string
-	LeftOwners  []string
-	RightOwners []string
-	Data        []byte
+	Minimum int
+	Owners  []string
+	Data    []byte
 
 	Labels []string
 }
@@ -102,7 +106,7 @@ func jsonStatusError(err error) ([]byte, error) {
 	return json.Marshal(ResponseData{Status: err.Error()})
 }
 func jsonSummary() ([]byte, error) {
-	return json.Marshal(SummaryData{Status: "ok", Live: keycache.GetSummary(), All: passvault.GetSummary()})
+	return json.Marshal(SummaryData{Status: "ok", Live: cache.GetSummary(), All: records.GetSummary()})
 }
 func jsonResponse(resp []byte) ([]byte, error) {
 	return json.Marshal(ResponseData{Status: "ok", Response: resp})
@@ -111,11 +115,11 @@ func jsonResponse(resp []byte) ([]byte, error) {
 // validateAdmin checks that the username and password passed in are
 // correct and that the user is an admin
 func validateAdmin(name, password string) error {
-	if passvault.NumRecords() == 0 {
+	if records.NumRecords() == 0 {
 		return errors.New("Vault is not created yet")
 	}
 
-	pr, ok := passvault.GetRecord(name)
+	pr, ok := records.GetRecord(name)
 	if !ok {
 		return errors.New("User not present")
 	}
@@ -144,9 +148,13 @@ func validateUser(name, password string) error {
 
 // Init reads the records from disk from a given path
 func Init(path string) (err error) {
-	if err = passvault.InitFromDisk(path); err != nil {
+	if records, err = passvault.InitFrom(path); err != nil {
 		err = fmt.Errorf("Failed to load password vault %s: %s", path, err)
 	}
+
+	cache = keycache.Cache{make(map[string]keycache.ActiveUser)}
+	crypt = cryptor.New(&records, &cache)
+
 	return
 }
 
@@ -157,7 +165,7 @@ func Create(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	if passvault.NumRecords() != 0 {
+	if records.NumRecords() != 0 {
 		return jsonStatusError(errors.New("Vault is already created"))
 	}
 
@@ -166,7 +174,7 @@ func Create(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	if _, err := passvault.AddNewRecord(s.Name, s.Password, true); err != nil {
+	if _, err := records.AddNewRecord(s.Name, s.Password, true, passvault.DefaultRecordType); err != nil {
 		log.Printf("Error adding record for %s: %s\n", s.Name, err)
 		return jsonStatusError(err)
 	}
@@ -177,13 +185,13 @@ func Create(jsonIn []byte) ([]byte, error) {
 // Summary processes a summary request.
 func Summary(jsonIn []byte) ([]byte, error) {
 	var s SummaryRequest
-	keycache.Refresh()
+	cache.Refresh()
 
 	if err := json.Unmarshal(jsonIn, &s); err != nil {
 		return jsonStatusError(err)
 	}
 
-	if passvault.NumRecords() == 0 {
+	if records.NumRecords() == 0 {
 		return jsonStatusError(errors.New("Vault is not created yet"))
 	}
 
@@ -202,7 +210,7 @@ func Delegate(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	if passvault.NumRecords() == 0 {
+	if records.NumRecords() == 0 {
 		return jsonStatusError(errors.New("Vault is not created yet"))
 	}
 
@@ -214,21 +222,21 @@ func Delegate(jsonIn []byte) ([]byte, error) {
 	// Find password record for user and verify that their password
 	// matches. If not found then add a new entry for this user.
 
-	pr, found := passvault.GetRecord(s.Name)
+	pr, found := records.GetRecord(s.Name)
 	if found {
 		if err := pr.ValidatePassword(s.Password); err != nil {
 			return jsonStatusError(err)
 		}
 	} else {
 		var err error
-		if pr, err = passvault.AddNewRecord(s.Name, s.Password, false); err != nil {
+		if pr, err = records.AddNewRecord(s.Name, s.Password, false, passvault.DefaultRecordType); err != nil {
 			log.Printf("Error adding record for %s: %s\n", s.Name, err)
 			return jsonStatusError(err)
 		}
 	}
 
 	// add signed-in record to active set
-	if err := keycache.AddKeyFromRecord(pr, s.Name, s.Password, s.Users, s.Labels, s.Uses, s.Time); err != nil {
+	if err := cache.AddKeyFromRecord(pr, s.Name, s.Password, s.Users, s.Labels, s.Uses, s.Time); err != nil {
 		log.Printf("Error adding key to cache for %s: %s\n", s.Name, err)
 		return jsonStatusError(err)
 	}
@@ -243,12 +251,12 @@ func Password(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	if passvault.NumRecords() == 0 {
+	if records.NumRecords() == 0 {
 		return jsonStatusError(errors.New("Vault is not created yet"))
 	}
 
 	// add signed-in record to active set
-	if err := passvault.ChangePassword(s.Name, s.Password, s.NewPassword); err != nil {
+	if err := records.ChangePassword(s.Name, s.Password, s.NewPassword); err != nil {
 		log.Println("Error changing password:", err)
 		return jsonStatusError(err)
 	}
@@ -268,13 +276,8 @@ func Encrypt(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	if len(s.Owners) > 0 {
-		s.LeftOwners = s.Owners
-		s.RightOwners = s.Owners
-	}
-
 	// Encrypt file with list of owners
-	if resp, err := cryptor.Encrypt(s.Data, s.Labels, s.LeftOwners, s.RightOwners, s.Minimum); err != nil {
+	if resp, err := crypt.Encrypt(s.Data, s.Labels, s.Owners, s.Minimum); err != nil {
 		log.Println("Error encrypting:", err)
 		return jsonStatusError(err)
 	} else {
@@ -296,7 +299,7 @@ func Decrypt(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	data, names, err := cryptor.Decrypt(s.Data, s.Name)
+	data, names, err := crypt.Decrypt(s.Data, s.Name)
 	if err != nil {
 		log.Println("Error decrypting:", err)
 		return jsonStatusError(err)
@@ -328,7 +331,7 @@ func Modify(jsonIn []byte) ([]byte, error) {
 		return jsonStatusError(err)
 	}
 
-	if _, ok := passvault.GetRecord(s.ToModify); !ok {
+	if _, ok := records.GetRecord(s.ToModify); !ok {
 		return jsonStatusError(errors.New("Record to modify missing"))
 	}
 
@@ -339,11 +342,11 @@ func Modify(jsonIn []byte) ([]byte, error) {
 	var err error
 	switch s.Command {
 	case "delete":
-		err = passvault.DeleteRecord(s.ToModify)
+		err = records.DeleteRecord(s.ToModify)
 	case "revoke":
-		err = passvault.RevokeRecord(s.ToModify)
+		err = records.RevokeRecord(s.ToModify)
 	case "admin":
-		err = passvault.MakeAdmin(s.ToModify)
+		err = records.MakeAdmin(s.ToModify)
 	default:
 		return jsonStatusError(errors.New("Unknown command"))
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudflare/redoctober/keycache"
 	"github.com/cloudflare/redoctober/passvault"
 )
 
@@ -156,7 +155,7 @@ func TestSummary(t *testing.T) {
 
 	dataLive, ok := s.Live["Bob"]
 	if !ok {
-		t.Fatalf("Error in summary of account, record missing, %v", keycache.UserKeys)
+		t.Fatalf("Error in summary of account, record missing, %v", cache.UserKeys)
 	}
 	if dataLive.Admin != false {
 		t.Fatalf("Error in summary of account, record missing")
@@ -165,7 +164,7 @@ func TestSummary(t *testing.T) {
 		t.Fatalf("Error in summary of account, record missing")
 	}
 
-	keycache.FlushCache()
+	cache.FlushCache()
 
 	os.Remove("/tmp/db1.json")
 }
@@ -278,7 +277,7 @@ func TestPassword(t *testing.T) {
 		t.Fatalf("Error in delegating account, %v", s.Status)
 	}
 
-	keycache.FlushCache()
+	cache.FlushCache()
 
 	os.Remove("/tmp/db1.json")
 }
@@ -335,7 +334,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 
 	// check summary to see if none are delegated
-	keycache.Refresh()
+	cache.Refresh()
 	respJson, err = Summary(summaryJson)
 	if err != nil {
 		t.Fatalf("Error in summary, %v", err)
@@ -422,7 +421,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 
 	// verify the presence of the two delgations
-	keycache.Refresh()
+	cache.Refresh()
 	var sum2 SummaryData
 	respJson, err = Summary(summaryJson)
 	if err != nil {
@@ -467,7 +466,7 @@ func TestEncryptDecrypt(t *testing.T) {
 		}
 	}
 
-	keycache.FlushCache()
+	cache.FlushCache()
 
 	os.Remove("/tmp/db1.json")
 }
@@ -526,7 +525,7 @@ func TestModify(t *testing.T) {
 	}
 
 	// check summary to see if none are delegated
-	keycache.Refresh()
+	cache.Refresh()
 	respJson, err = Summary(summaryJson)
 	if err != nil {
 		t.Fatalf("Error in summary, %v", err)
@@ -654,7 +653,7 @@ func TestModify(t *testing.T) {
 		t.Fatalf("Error in summary, %v", sum3.All)
 	}
 
-	keycache.FlushCache()
+	cache.FlushCache()
 
 	os.Remove("/tmp/db1.json")
 }
@@ -731,7 +730,7 @@ func TestStatic(t *testing.T) {
 		t.Fatalf("Error in summary, %v, %v", expected, r.Response)
 	}
 
-	keycache.FlushCache()
+	cache.FlushCache()
 
 	os.Remove("/tmp/db1.json")
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -16,8 +16,7 @@ import (
 func TestCreate(t *testing.T) {
 	createJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\"}")
 
-	os.Remove("/tmp/db1.json")
-	Init("/tmp/db1.json")
+	Init("memory")
 
 	respJson, err := Create(createJson)
 	if err != nil {
@@ -45,14 +44,11 @@ func TestCreate(t *testing.T) {
 	if s.Status == "ok" {
 		t.Fatalf("Error in creating account when one exists, %v", s.Status)
 	}
-
-	os.Remove("/tmp/db1.json")
 }
 
 func TestSummary(t *testing.T) {
 	createJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\"}")
 	delegateJson := []byte("{\"Name\":\"Bob\",\"Password\":\"Rob\",\"Time\":\"2h\",\"Uses\":1}")
-	os.Remove("/tmp/db1.json")
 
 	// check for summary of uninitialized vault
 	respJson, err := Summary(createJson)
@@ -68,7 +64,7 @@ func TestSummary(t *testing.T) {
 		t.Fatalf("Error in summary of account with no vault, %v", s.Status)
 	}
 
-	Init("/tmp/db1.json")
+	Init("memory")
 
 	// check for summary of initialized vault
 	respJson, err = Create(createJson)
@@ -163,10 +159,6 @@ func TestSummary(t *testing.T) {
 	if dataLive.Type != passvault.DefaultRecordType {
 		t.Fatalf("Error in summary of account, record missing")
 	}
-
-	cache.FlushCache()
-
-	os.Remove("/tmp/db1.json")
 }
 
 func TestPassword(t *testing.T) {
@@ -175,9 +167,8 @@ func TestPassword(t *testing.T) {
 	passwordJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"NewPassword\":\"Olleh\"}")
 	delegateJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Olleh\",\"Time\":\"2h\",\"Uses\":1}")
 	passwordJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Olleh\",\"NewPassword\":\"Hello\"}")
-	os.Remove("/tmp/db1.json")
 
-	Init("/tmp/db1.json")
+	Init("memory")
 
 	// check for summary of initialized vault with new member
 	var s ResponseData
@@ -276,10 +267,6 @@ func TestPassword(t *testing.T) {
 	if s.Status != "ok" {
 		t.Fatalf("Error in delegating account, %v", s.Status)
 	}
-
-	cache.FlushCache()
-
-	os.Remove("/tmp/db1.json")
 }
 
 func TestEncryptDecrypt(t *testing.T) {
@@ -291,9 +278,8 @@ func TestEncryptDecrypt(t *testing.T) {
 	delegateJson5 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"10s\",\"Uses\":2,\"Users\":[\"Alice\"],\"Labels\":[\"blue\"]}")
 	encryptJson := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Minumum\":2,\"Owners\":[\"Alice\",\"Bob\",\"Carol\"],\"Data\":\"SGVsbG8gSmVsbG8=\"}")
 	encryptJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Minumum\":2,\"Owners\":[\"Alice\",\"Bob\",\"Carol\"],\"Data\":\"SGVsbG8gSmVsbG8=\",\"Labels\":[\"blue\",\"red\"]}")
-	os.Remove("/tmp/db1.json")
 
-	Init("/tmp/db1.json")
+	Init("memory")
 
 	// check for summary of initialized vault with new member
 	var s ResponseData
@@ -465,10 +451,6 @@ func TestEncryptDecrypt(t *testing.T) {
 			t.Fatalf("Error in decrypt, %v", d.Delegates)
 		}
 	}
-
-	cache.FlushCache()
-
-	os.Remove("/tmp/db1.json")
 }
 
 func TestModify(t *testing.T) {
@@ -483,8 +465,7 @@ func TestModify(t *testing.T) {
 	modifyJson4 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"ToModify\":\"Alice\",\"Command\":\"revoke\"}")
 	modifyJson5 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"ToModify\":\"Alice\",\"Command\":\"delete\"}")
 
-	os.Remove("/tmp/db1.json")
-	Init("/tmp/db1.json")
+	Init("memory")
 
 	// check for summary of initialized vault with new member
 	var s ResponseData
@@ -652,10 +633,6 @@ func TestModify(t *testing.T) {
 	if len(sum3.All) != 2 {
 		t.Fatalf("Error in summary, %v", sum3.All)
 	}
-
-	cache.FlushCache()
-
-	os.Remove("/tmp/db1.json")
 }
 
 func TestStatic(t *testing.T) {

--- a/cryptor/cryptor.go
+++ b/cryptor/cryptor.go
@@ -358,7 +358,7 @@ func (encrypted *EncryptedData) unwrapKey(cache *keycache.Cache, user string) (u
 func (c *Cryptor) Encrypt(in []byte, labels []string, access AccessStructure) (resp []byte, err error) {
 	var encrypted EncryptedData
 	encrypted.Version = DEFAULT_VERSION
-	if encrypted.VaultId, err = c.records.GetVaultId(); err != nil {
+	if encrypted.VaultId, err = c.records.GetVaultID(); err != nil {
 		return
 	}
 
@@ -393,7 +393,7 @@ func (c *Cryptor) Encrypt(in []byte, labels []string, access AccessStructure) (r
 	encrypted.Data = encryptedFile
 	encrypted.Labels = labels
 
-	hmacKey, err := c.records.GetHmacKey()
+	hmacKey, err := c.records.GetHMACKey()
 	if err != nil {
 		return
 	}
@@ -416,7 +416,7 @@ func (c *Cryptor) Decrypt(in []byte, user string) (resp []byte, names []string, 
 
 	secure = encrypted.Version == -1
 
-	hmacKey, err := c.records.GetHmacKey()
+	hmacKey, err := c.records.GetHMACKey()
 	if err != nil {
 		return
 	}
@@ -426,7 +426,7 @@ func (c *Cryptor) Decrypt(in []byte, user string) (resp []byte, names []string, 
 	}
 
 	// make sure file was encrypted with the active vault
-	vaultId, err := c.records.GetVaultId()
+	vaultId, err := c.records.GetVaultID()
 	if err != nil {
 		return
 	}

--- a/cryptor/cryptor.go
+++ b/cryptor/cryptor.go
@@ -92,8 +92,6 @@ func encryptKey(nameInner, nameOuter string, clearKey []byte, pubKeys map[string
 			err = errors.New("Missing user in file")
 			return
 		}
-	case passvault.AESRecord:
-		break
 
 	default:
 		return out, errors.New("Unknown record type inner")

--- a/cryptor/cryptor.go
+++ b/cryptor/cryptor.go
@@ -25,6 +25,15 @@ const (
 	DEFAULT_VERSION = 1
 )
 
+type Cryptor struct {
+	records *passvault.Records
+	cache   *keycache.Cache
+}
+
+func New(records *passvault.Records, cache *keycache.Cache) Cryptor {
+	return Cryptor{records, cache}
+}
+
 // MultiWrappedKey is a structure containing a 16-byte key encrypted
 // once for each of the keys corresponding to the names of the users
 // in Name in order.
@@ -53,174 +62,47 @@ type EncryptedData struct {
 	Signature []byte
 }
 
-// encryptKey encrypts data with the key associated with name inner,
-// then name outer
-func encryptKey(nameInner, nameOuter string, clearKey []byte, pubKeys map[string]SingleWrappedKey) (out MultiWrappedKey, err error) {
-	out.Name = []string{nameOuter, nameInner}
-
-	recInner, ok := passvault.GetRecord(nameInner)
-	if !ok {
-		err = errors.New("Missing user on disk")
-		return
-	}
-
-	recOuter, ok := passvault.GetRecord(nameOuter)
-	if !ok {
-		err = errors.New("Missing user on disk")
-		return
-	}
-
-	if recInner.Type != recOuter.Type {
-		err = errors.New("Mismatched record types")
-		return
-	}
-
-	var keyBytes []byte
-	var overrideInner SingleWrappedKey
-	var overrideOuter SingleWrappedKey
-
-	// For AES records, use the live user key
-	// For RSA and ECC records, use the public key from the passvault
-	switch recInner.Type {
-	case passvault.RSARecord, passvault.ECCRecord:
-		if overrideInner, ok = pubKeys[nameInner]; !ok {
-			err = errors.New("Missing user in file")
-			return
-		}
-
-		if overrideOuter, ok = pubKeys[nameOuter]; !ok {
-			err = errors.New("Missing user in file")
-			return
-		}
-
-	default:
-		return out, errors.New("Unknown record type inner")
-	}
-
-	// double-wrap the keys
-	if keyBytes, err = keycache.EncryptKey(clearKey, nameInner, overrideInner.aesKey); err != nil {
-		return out, err
-	}
-	if keyBytes, err = keycache.EncryptKey(keyBytes, nameOuter, overrideOuter.aesKey); err != nil {
-		return out, err
-	}
-
-	out.Key = keyBytes
-
-	return
+type pair struct {
+	name string
+	key  []byte
 }
 
-// unwrapKey decrypts first key in keys whose encryption keys are in keycache
-func unwrapKey(keys []MultiWrappedKey, pubKeys map[string]SingleWrappedKey, user string, labels []string) (unwrappedKey []byte, names []string, err error) {
-	var (
-		keyFound  error
-		fullMatch bool = false
-		nameSet        = map[string]bool{}
-	)
+type mwkSlice []MultiWrappedKey
+type swkSlice []pair
 
-	for _, mwKey := range keys {
-		if err != nil {
-			return nil, nil, err
-		}
-
-		tmpKeyValue := mwKey.Key
-
-		for _, mwName := range mwKey.Name {
-			pubEncrypted := pubKeys[mwName]
-			// if this is null, it's an AES encrypted key
-			if tmpKeyValue, keyFound = keycache.DecryptKey(tmpKeyValue, mwName, user, labels, pubEncrypted.Key); keyFound != nil {
-				break
-			}
-			nameSet[mwName] = true
-		}
-		if keyFound == nil {
-			fullMatch = true
-			// concatenate all the decrypted bytes
-			unwrappedKey = tmpKeyValue
-			break
-		}
-	}
-
-	if !fullMatch {
-		err = errors.New("Need more delegated keys")
-		names = nil
-	}
-
-	names = make([]string, 0, len(nameSet))
-	for name := range nameSet {
-		names = append(names, name)
-	}
-	return
-}
-
-// mwkSorter describes a slice of MultiWrappedKeys to be sorted.
-type mwkSorter struct {
-	keySet []MultiWrappedKey
-}
-
-// Len is part of sort.Interface.
-func (s *mwkSorter) Len() int {
-	return len(s.keySet)
-}
-
-// Swap is part of sort.Interface.
-func (s *mwkSorter) Swap(i, j int) {
-	s.keySet[i], s.keySet[j] = s.keySet[j], s.keySet[i]
-}
-
-// Less is part of sort.Interface, it sorts lexicographically
-// based on the list of names
-func (s *mwkSorter) Less(i, j int) bool {
+func (s mwkSlice) Len() int             { return len(s) }
+func (s mwkSlice) Swap(i, j int)        { s[i], s[j] = s[j], s[i] }
+func (s mwkSlice) Less(i, j int) bool { // Alphabetic order
 	var shorter = i
-	if len(s.keySet[i].Name) > len(s.keySet[j].Name) {
+	if len(s[i].Name) > len(s[j].Name) {
 		shorter = j
 	}
-	for index := range s.keySet[shorter].Name {
-		if s.keySet[i].Name[index] != s.keySet[j].Name[index] {
-			return s.keySet[i].Name[index] < s.keySet[j].Name[index]
+
+	for index := range s[shorter].Name {
+		if s[i].Name[index] != s[j].Name[index] {
+			return s[i].Name[index] < s[j].Name[index]
 		}
 	}
 
 	return false
 }
 
-// swkSorter joins a slice of names with SingleWrappedKeys to be sorted.
-type pair struct {
-	name string
-	key  []byte
-}
-
-type swkSorter []pair
-
-// Len is part of sort.Interface.
-func (s swkSorter) Len() int {
-	return len(s)
-}
-
-// Swap is part of sort.Interface.
-func (s swkSorter) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less is part of sort.Interface.
-func (s swkSorter) Less(i, j int) bool {
-	return s[i].name < s[j].name
-}
+func (s swkSlice) Len() int           { return len(s) }
+func (s swkSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s swkSlice) Less(i, j int) bool { return s[i].name < s[j].name }
 
 // computeHmac computes the signature of the encrypted data structure
 // the signature takes into account every element of the EncryptedData
 // structure, with all keys sorted alphabetically by name
-func computeHmac(key []byte, encrypted EncryptedData) []byte {
+func (encrypted *EncryptedData) computeHmac(key []byte) []byte {
 	mac := hmac.New(sha1.New, key)
 
 	// sort the multi-wrapped keys
-	mwks := &mwkSorter{
-		keySet: encrypted.KeySet,
-	}
+	mwks := mwkSlice(encrypted.KeySet)
 	sort.Sort(mwks)
 
 	// sort the singly-wrapped keys
-	var swks swkSorter
+	var swks swkSlice
 	for name, val := range encrypted.KeySetRSA {
 		swks = append(swks, pair{name, val.Key})
 	}
@@ -259,97 +141,141 @@ func computeHmac(key []byte, encrypted EncryptedData) []byte {
 	return mac.Sum(nil)
 }
 
+// wrapKey encrypts the clear key such that a minimum number of delegated keys
+// are required to decrypt.  NOTE:  Currently the max value for min is 2.
+func (encrypted *EncryptedData) wrapKey(records *passvault.Records, clearKey []byte, names []string, min int) (err error) {
+	// Generate a random AES key for each user and RSA/ECIES encrypt it
+	encrypted.KeySetRSA = make(map[string]SingleWrappedKey, len(names))
+
+	for _, name := range names {
+		rec, ok := records.GetRecord(name)
+		if !ok {
+			err = errors.New("Missing user on disk")
+			return
+		}
+
+		var singleWrappedKey SingleWrappedKey
+
+		if singleWrappedKey.aesKey, err = symcrypt.MakeRandom(16); err != nil {
+			return err
+		}
+
+		if singleWrappedKey.Key, err = rec.EncryptKey(singleWrappedKey.aesKey); err != nil {
+			return err
+		}
+
+		encrypted.KeySetRSA[name] = singleWrappedKey
+	}
+
+	// encrypt file key with every combination of two keys
+	encrypted.KeySet = make([]MultiWrappedKey, 0)
+
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			var outerCrypt, innerCrypt cipher.Block
+			keyBytes := make([]byte, 16)
+
+			outerCrypt, err = aes.NewCipher(encrypted.KeySetRSA[names[i]].aesKey)
+			if err != nil {
+				return
+			}
+
+			innerCrypt, err = aes.NewCipher(encrypted.KeySetRSA[names[j]].aesKey)
+			if err != nil {
+				return
+			}
+
+			innerCrypt.Encrypt(keyBytes, clearKey)
+			outerCrypt.Encrypt(keyBytes, keyBytes)
+
+			out := MultiWrappedKey{
+				Name: []string{names[i], names[j]},
+				Key:  keyBytes,
+			}
+
+			encrypted.KeySet = append(encrypted.KeySet, out)
+		}
+	}
+
+	return nil
+}
+
+// unwrapKey decrypts first key in keys whose encryption keys are in keycache
+func (encrypted *EncryptedData) unwrapKey(cache *keycache.Cache, user string) (unwrappedKey []byte, names []string, err error) {
+	var (
+		keyFound  error
+		fullMatch bool = false
+		nameSet        = map[string]bool{}
+	)
+
+	for _, mwKey := range encrypted.KeySet {
+		// validate the size of the keys
+		if len(mwKey.Key) != 16 {
+			err = errors.New("Invalid Input")
+		}
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		tmpKeyValue := mwKey.Key
+
+		for _, mwName := range mwKey.Name {
+			pubEncrypted := encrypted.KeySetRSA[mwName]
+			// if this is null, it's an AES encrypted key
+			if tmpKeyValue, keyFound = cache.DecryptKey(tmpKeyValue, mwName, user, encrypted.Labels, pubEncrypted.Key); keyFound != nil {
+				break
+			}
+			nameSet[mwName] = true
+		}
+		if keyFound == nil {
+			fullMatch = true
+			// concatenate all the decrypted bytes
+			unwrappedKey = tmpKeyValue
+			break
+		}
+	}
+
+	if !fullMatch {
+		err = errors.New("Need more delegated keys")
+		names = nil
+	}
+
+	names = make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	return
+}
+
 // Encrypt encrypts data with the keys associated with names. This
 // requires a minimum of min keys to decrypt.  NOTE: as currently
 // implemented, the maximum value for min is 2.
-func Encrypt(in []byte, labels, leftNames, rightNames []string, min int) (resp []byte, err error) {
+func (c *Cryptor) Encrypt(in []byte, labels, names []string, min int) (resp []byte, err error) {
 	if min > 2 {
 		return nil, errors.New("Minimum restricted to 2")
 	}
 
 	var encrypted EncryptedData
 	encrypted.Version = DEFAULT_VERSION
-	if encrypted.VaultId, err = passvault.GetVaultId(); err != nil {
+	if encrypted.VaultId, err = c.records.GetVaultId(); err != nil {
 		return
 	}
 
 	// Generate random IV and encryption key
-	ivBytes, err := symcrypt.MakeRandom(16)
+	encrypted.IV, err = symcrypt.MakeRandom(16)
 	if err != nil {
 		return
 	}
 
-	// append used here to make a new slice from ivBytes and assign to
-	// encrypted.IV
-
-	encrypted.IV = append([]byte{}, ivBytes...)
 	clearKey, err := symcrypt.MakeRandom(16)
 	if err != nil {
 		return
 	}
 
-	var names = make(map[string]bool)
-	var overlap int
-
-	// Count overlapping names, we don't want to double-encrypt
-	// with the same name
-	for _, n := range leftNames {
-		names[n] = true
-	}
-	for _, n := range rightNames {
-		used, ok := names[n]
-		if !used && ok {
-			names[n] = true
-		} else {
-			overlap++
-		}
-	}
-
-	// Allocate set of keys to be able to cover all unequal pairs of
-	// names with one from leftNames and one from rightNames
-
-	// Combinatorially, the number of ordered pairs with one element
-	// from one set and one from another for which both elements of
-	// the pair is distinct is
-	// len(n) * len(k) - overlap
-	encrypted.KeySet = make([]MultiWrappedKey, (len(leftNames)*len(rightNames) - overlap))
-	encrypted.KeySetRSA = make(map[string]SingleWrappedKey)
-
-	var singleWrappedKey SingleWrappedKey
-	for name := range names {
-		rec, ok := passvault.GetRecord(name)
-		if !ok {
-			err = errors.New("Missing user on disk")
-			return
-		}
-
-		if rec.GetType() == passvault.RSARecord || rec.GetType() == passvault.ECCRecord {
-			// only wrap key with RSA key if found
-			if singleWrappedKey.aesKey, err = symcrypt.MakeRandom(16); err != nil {
-				return nil, err
-			}
-
-			if singleWrappedKey.Key, err = rec.EncryptKey(singleWrappedKey.aesKey); err != nil {
-				return nil, err
-			}
-			encrypted.KeySetRSA[name] = singleWrappedKey
-		} else {
-			err = nil
-		}
-	}
-
-	// encrypt file key with every combination of two keys
-	var n int
-	for _, nameOuter := range leftNames {
-		for _, nameInner := range rightNames {
-			if nameInner != nameOuter {
-				encrypted.KeySet[n], err = encryptKey(nameInner, nameOuter, clearKey, encrypted.KeySetRSA)
-				n += 1
-			}
-			if err != nil {
-				return
-			}
-		}
+	err = encrypted.wrapKey(c.records, clearKey, names, min)
+	if err != nil {
+		return
 	}
 
 	// encrypt file with clear key
@@ -361,23 +287,23 @@ func Encrypt(in []byte, labels, leftNames, rightNames []string, min int) (resp [
 	clearFile := padding.AddPadding(in)
 
 	encryptedFile := make([]byte, len(clearFile))
-	aesCBC := cipher.NewCBCEncrypter(aesCrypt, ivBytes)
+	aesCBC := cipher.NewCBCEncrypter(aesCrypt, encrypted.IV)
 	aesCBC.CryptBlocks(encryptedFile, clearFile)
 
 	encrypted.Data = encryptedFile
 	encrypted.Labels = labels
 
-	hmacKey, err := passvault.GetHmacKey()
+	hmacKey, err := c.records.GetHmacKey()
 	if err != nil {
 		return
 	}
-	encrypted.Signature = computeHmac(hmacKey, encrypted)
+	encrypted.Signature = encrypted.computeHmac(hmacKey)
 
 	return json.Marshal(encrypted)
 }
 
 // Decrypt decrypts a file using the keys in the key cache.
-func Decrypt(in []byte, user string) (resp []byte, names []string, err error) {
+func (c *Cryptor) Decrypt(in []byte, user string) (resp []byte, names []string, err error) {
 	// unwrap encrypted file
 	var encrypted EncryptedData
 	if err = json.Unmarshal(in, &encrypted); err != nil {
@@ -388,7 +314,7 @@ func Decrypt(in []byte, user string) (resp []byte, names []string, err error) {
 	}
 
 	// make sure file was encrypted with the active vault
-	vaultId, err := passvault.GetVaultId()
+	vaultId, err := c.records.GetVaultId()
 	if err != nil {
 		return
 	}
@@ -396,20 +322,12 @@ func Decrypt(in []byte, user string) (resp []byte, names []string, err error) {
 		return nil, nil, errors.New("Wrong vault")
 	}
 
-	// validate the size of the keys
-	for _, multiKey := range encrypted.KeySet {
-		if len(multiKey.Key) != 16 {
-			err = errors.New("Invalid Input")
-			return
-		}
-	}
-
 	// compute HMAC
-	hmacKey, err := passvault.GetHmacKey()
+	hmacKey, err := c.records.GetHmacKey()
 	if err != nil {
 		return
 	}
-	expectedMAC := computeHmac(hmacKey, encrypted)
+	expectedMAC := encrypted.computeHmac(hmacKey)
 	if !hmac.Equal(encrypted.Signature, expectedMAC) {
 		err = errors.New("Signature mismatch")
 		return
@@ -417,7 +335,7 @@ func Decrypt(in []byte, user string) (resp []byte, names []string, err error) {
 
 	// decrypt file key with delegate keys
 	var unwrappedKey = make([]byte, 16)
-	unwrappedKey, names, err = unwrapKey(encrypted.KeySet, encrypted.KeySetRSA, user, encrypted.Labels)
+	unwrappedKey, names, err = encrypted.unwrapKey(c.cache, user)
 	if err != nil {
 		return
 	}

--- a/cryptor/cryptor_test.go
+++ b/cryptor/cryptor_test.go
@@ -22,7 +22,7 @@ func TestHash(t *testing.T) {
 	var hmacKey, _ = base64.StdEncoding.DecodeString("Qugc5ZQ0vC7KQSgmDHTVgQ==")
 	var signature = append([]byte{}, encrypted.Signature...)
 
-	expectedSig := computeHmac(hmacKey, encrypted)
+	expectedSig := encrypted.computeHmac(hmacKey)
 
 	if diff := bytes.Compare(signature, expectedSig); diff != 0 {
 		t.Fatalf("Error comparing signature %v", base64.StdEncoding.EncodeToString(expectedSig))
@@ -30,7 +30,7 @@ func TestHash(t *testing.T) {
 
 	// change version and check hmac
 	encrypted.Version = 2
-	unexpectedSig := computeHmac(hmacKey, encrypted)
+	unexpectedSig := encrypted.computeHmac(hmacKey)
 
 	if diff := bytes.Compare(signature, unexpectedSig); diff == 0 {
 		t.Fatalf("Error comparing signature")
@@ -39,7 +39,7 @@ func TestHash(t *testing.T) {
 
 	// change vaultid and check hmac
 	encrypted.VaultId = 529853896
-	unexpectedSig = computeHmac(hmacKey, encrypted)
+	unexpectedSig = encrypted.computeHmac(hmacKey)
 
 	if diff := bytes.Compare(signature, unexpectedSig); diff == 0 {
 		t.Fatalf("Error comparing signature")
@@ -48,7 +48,7 @@ func TestHash(t *testing.T) {
 
 	// swap two records and check hmac
 	encrypted.KeySet[0], encrypted.KeySet[1] = encrypted.KeySet[1], encrypted.KeySet[0]
-	unexpectedSig = computeHmac(hmacKey, encrypted)
+	unexpectedSig = encrypted.computeHmac(hmacKey)
 
 	if diff := bytes.Compare(signature, unexpectedSig); diff != 0 {
 		t.Fatalf("Error comparing signature %v, %v",
@@ -59,7 +59,7 @@ func TestHash(t *testing.T) {
 	// delete RSA key and check hmac
 	encrypted.Version = 1
 	delete(encrypted.KeySetRSA, "Carol")
-	unexpectedSig = computeHmac(hmacKey, encrypted)
+	unexpectedSig = encrypted.computeHmac(hmacKey)
 
 	if diff := bytes.Compare(signature, unexpectedSig); diff == 0 {
 		t.Fatalf("Error comparing signature")

--- a/index.html
+++ b/index.html
@@ -485,7 +485,7 @@
 					data : data,
 					success : function(d){
 					d = JSON.parse(window.atob(d.Response));
-					$form.find('.feedback').empty().append( makeAlert({ type: 'success', message: '<p>Successfully decrypted data:</p><pre>'+ window.atob(d.Data)+'</pre><p>Delegates: '+d.Delegates.sort().join(', ')+'</p>' }) );
+					$form.find('.feedback').empty().append( makeAlert({ type: (d.Secure ? 'success' : 'warning'), message: '<p>Successfully decrypted data:</p><pre>'+ window.atob(d.Data)+'</pre><p>Delegates: '+d.Delegates.sort().join(', ')+'</p>' }) );
 					}
 				});
 			});

--- a/index.html
+++ b/index.html
@@ -385,10 +385,12 @@
 				data.Users = data.Users.split(',');
 				for(var i=0, l=data.Users.length; i<l; i++){
 					data.Users[i] = data.Users[i].trim();
+					if (data.Users[i] == "") { data.Users.splice(i, 1); }
 				}
 				data.Labels = data.Labels.split(',');
 				for(var i=0, l=data.Labels.length; i<l; i++){
 					data.Labels[i] = data.Labels[i].trim();
+					if (data.Labels[i] == "") { data.Labels.splice(i, 1); }
 				}
 
 				submit( $form, {
@@ -454,10 +456,12 @@
 				data.Owners = data.Owners.split(',');
 				for(var i=0, l=data.Owners.length; i<l; i++){
 					data.Owners[i] = data.Owners[i].trim();
+					if (data.Owners[i] == "") { data.Owners.splice(i, 1); }
 				}
 				data.Labels = data.Labels.split(',');
 				for(var i=0, l=data.Labels.length; i<l; i++){
 					data.Labels[i] = data.Labels[i].trim();
+					if (data.Labels[i] == "") { data.Labels.splice(i, 1); }
 				}
 
 				// Convert data to base64.

--- a/keycache/keycache.go
+++ b/keycache/keycache.go
@@ -19,9 +19,6 @@ import (
 	"github.com/cloudflare/redoctober/passvault"
 )
 
-// UserKeys is the set of decrypted keys in memory, indexed by name.
-var UserKeys map[string]ActiveUser = make(map[string]ActiveUser)
-
 // Usage holds the permissions of a delegated permission
 type Usage struct {
 	Uses   int       // Number of uses delegated
@@ -40,24 +37,8 @@ type ActiveUser struct {
 	eccKey *ecdsa.PrivateKey
 }
 
-// matchUser returns the matching active user if present
-// and a boolean to indicate its presence.
-func matchUser(name, user string, labels []string) (out ActiveUser, present bool) {
-	key, present := UserKeys[name]
-	if present {
-		if key.Usage.matches(user, labels) {
-			return key, true
-		} else {
-			present = false
-		}
-	}
-
-	return
-}
-
-// setUser takes an ActiveUser and adds it to the cache.
-func setUser(in ActiveUser, name string) {
-	UserKeys[name] = in
+type Cache struct {
+	UserKeys map[string]ActiveUser // Decrypted keys in memory, indexed by name.
 }
 
 // matchesLabel returns true if this usage applies the user and label
@@ -96,42 +77,66 @@ func (usage Usage) matches(user string, labels []string) bool {
 	return false
 }
 
+func NewCache() Cache {
+	return Cache{make(map[string]ActiveUser)}
+}
+
+// setUser takes an ActiveUser and adds it to the cache.
+func (cache *Cache) setUser(in ActiveUser, name string) {
+	cache.UserKeys[name] = in
+}
+
+// matchUser returns the matching active user if present
+// and a boolean to indicate its presence.
+func (cache *Cache) matchUser(name, user string, labels []string) (out ActiveUser, present bool) {
+	key, present := cache.UserKeys[name]
+	if present {
+		if key.Usage.matches(user, labels) {
+			return key, true
+		} else {
+			present = false
+		}
+	}
+
+	return
+}
+
 // useKey decrements the counter on an active key
 // for decryption or symmetric encryption
-func useKey(name, user string, labels []string) {
-	if val, present := matchUser(name, user, labels); present {
+func (cache *Cache) useKey(name, user string, labels []string) {
+	if val, present := cache.matchUser(name, user, labels); present {
 		val.Usage.Uses -= 1
-		setUser(val, name)
+		cache.setUser(val, name)
 	}
 }
 
 // GetSummary returns the list of active user keys.
-func GetSummary() map[string]ActiveUser {
-	return UserKeys
+func (cache *Cache) GetSummary() map[string]ActiveUser {
+	return cache.UserKeys
 }
 
 // FlushCache removes all delegated keys.
-func FlushCache() {
-	for name := range UserKeys {
-		delete(UserKeys, name)
+func (cache *Cache) FlushCache() {
+	for name := range cache.UserKeys {
+		delete(cache.UserKeys, name)
 	}
 }
 
 // Refresh purges all expired or used up keys.
-func Refresh() {
-	for name, active := range UserKeys {
+func (cache *Cache) Refresh() {
+	for name, active := range cache.UserKeys {
 		if active.Usage.Expiry.Before(time.Now()) || active.Usage.Uses <= 0 {
 			log.Println("Record expired", name, active.Usage.Users, active.Usage.Labels, active.Usage.Expiry)
-			delete(UserKeys, name)
+			delete(cache.UserKeys, name)
 		}
 	}
 }
 
 // AddKeyFromRecord decrypts a key for a given record and adds it to the cache.
-func AddKeyFromRecord(record passvault.PasswordRecord, name, password string, users, labels []string, uses int, durationString string) (err error) {
+func (cache *Cache) AddKeyFromRecord(record passvault.PasswordRecord, name, password string, users, labels []string, uses int, durationString string) (err error) {
 	var current ActiveUser
 
-	Refresh()
+	cache.Refresh()
 
 	// compute exipiration
 	duration, err := time.ParseDuration(durationString)
@@ -162,22 +167,7 @@ func AddKeyFromRecord(record passvault.PasswordRecord, name, password string, us
 	current.Admin = record.Admin
 
 	// add current to map (overwriting previous for this name)
-	setUser(current, name)
-
-	return
-}
-
-// EncryptKey encrypts a 16 byte key using the cached key corresponding to name.
-func EncryptKey(in []byte, name string, aesKey []byte) (out []byte, err error) {
-	Refresh()
-
-	// encrypt
-	aesSession, err := aes.NewCipher(aesKey)
-	if err != nil {
-		return
-	}
-	out = make([]byte, 16)
-	aesSession.Encrypt(out, in)
+	cache.setUser(current, name)
 
 	return
 }
@@ -186,10 +176,10 @@ func EncryptKey(in []byte, name string, aesKey []byte) (out []byte, err error) {
 // For RSA and EC keys, the cached RSA/EC key is used to decrypt
 // the pubEncryptedKey which is then used to decrypt the input
 // buffer.
-func DecryptKey(in []byte, name, user string, labels []string, pubEncryptedKey []byte) (out []byte, err error) {
-	Refresh()
+func (cache *Cache) DecryptKey(in []byte, name, user string, labels []string, pubEncryptedKey []byte) (out []byte, err error) {
+	cache.Refresh()
 
-	decryptKey, ok := matchUser(name, user, labels)
+	decryptKey, ok := cache.matchUser(name, user, labels)
 	if !ok {
 		return nil, errors.New("Key not delegated")
 	}
@@ -223,7 +213,7 @@ func DecryptKey(in []byte, name, user string, labels []string, pubEncryptedKey [
 	out = make([]byte, 16)
 	aesSession.Decrypt(out, in)
 
-	useKey(name, user, labels)
+	cache.useKey(name, user, labels)
 
 	return
 }

--- a/passvault/passvault.go
+++ b/passvault/passvault.go
@@ -343,13 +343,13 @@ func InitFrom(path string) (records Records, err error) {
 func (records *Records) WriteRecordsToDisk() error {
 	if records.localPath == "memory" {
 		return nil
-	} else {
-		jsonDiskRecord, err := json.Marshal(records)
-		if err != nil {
-			return err
-		}
-		return ioutil.WriteFile(records.localPath, jsonDiskRecord, 0644)
 	}
+
+	jsonDiskRecord, err := json.Marshal(records)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(records.localPath, jsonDiskRecord, 0644)
 }
 
 // AddNewRecord adds a new record for a given username and password.
@@ -429,9 +429,8 @@ func (records *Records) DeleteRecord(name string) error {
 	if _, ok := records.GetRecord(name); ok {
 		delete(records.Passwords, name)
 		return records.WriteRecordsToDisk()
-	} else {
-		return errors.New("Record missing")
 	}
+	return errors.New("Record missing")
 }
 
 // RevokeRecord removes admin status from a record.
@@ -440,9 +439,8 @@ func (records *Records) RevokeRecord(name string) error {
 		rec.Admin = false
 		records.SetRecord(rec, name)
 		return records.WriteRecordsToDisk()
-	} else {
-		return errors.New("Record missing")
 	}
+	return errors.New("Record missing")
 }
 
 // MakeAdmin adds admin status to a given record.
@@ -451,9 +449,8 @@ func (records *Records) MakeAdmin(name string) error {
 		rec.Admin = true
 		records.SetRecord(rec, name)
 		return records.WriteRecordsToDisk()
-	} else {
-		return errors.New("Record missing")
 	}
+	return errors.New("Record missing")
 }
 
 // SetRecord puts a record into the global status.
@@ -516,18 +513,16 @@ func (pr *PasswordRecord) EncryptKey(in []byte) (out []byte, err error) {
 func (pr *PasswordRecord) GetKeyRSAPub() (out *rsa.PublicKey, err error) {
 	if pr.Type != RSARecord {
 		return out, errors.New("Invalid function for record type")
-	} else {
-		return &pr.RSAKey.RSAPublic, err
 	}
+	return &pr.RSAKey.RSAPublic, err
 }
 
 // GetKeyECCPub returns the ECDSA public key out of the record.
 func (pr *PasswordRecord) GetKeyECCPub() (out *ecdsa.PublicKey, err error) {
 	if pr.Type != ECCRecord {
 		return out, errors.New("Invalid function for record type")
-	} else {
-		return pr.ECKey.ECPublic.toECDSA(), err
 	}
+	return pr.ECKey.ECPublic.toECDSA(), err
 }
 
 // GetKeyECC returns the ECDSA private key of the record given the correct password.
@@ -623,7 +618,6 @@ func (pr *PasswordRecord) ValidatePassword(password string) error {
 
 	if bytes.Compare(h, pr.HashedPassword) != 0 {
 		return errors.New("Wrong Password")
-	} else {
-		return nil
 	}
+	return nil
 }

--- a/passvault/passvault.go
+++ b/passvault/passvault.go
@@ -46,9 +46,6 @@ const (
 	DEFAULT_VERSION = 1
 )
 
-// Path of current vault
-var localPath string
-
 type ECPublicKey struct {
 	Curve *elliptic.CurveParams
 	X, Y  *big.Int
@@ -92,16 +89,14 @@ type PasswordRecord struct {
 
 // diskRecords is the structure used to read and write a JSON file
 // containing the contents of a password vault
-type diskRecords struct {
+type Records struct {
 	Version   int
 	VaultId   int
 	HmacKey   []byte
 	Passwords map[string]PasswordRecord
-}
 
-// records is the set of encrypted records read from disk and
-// unmarshalled
-var records diskRecords
+	localPath string // Path of current vault
+}
 
 // Summary is a minmial account summary.
 type Summary struct {
@@ -171,8 +166,8 @@ func encryptECCRecord(newRec *PasswordRecord, ecPriv *ecdsa.PrivateKey, passKey 
 }
 
 // createPasswordRec creates a new record from a username and password
-func createPasswordRec(password string, admin bool) (newRec PasswordRecord, err error) {
-	newRec.Type = DefaultRecordType
+func createPasswordRec(password string, admin bool, userType string) (newRec PasswordRecord, err error) {
+	newRec.Type = userType
 
 	if newRec.PasswordSalt, err = symcrypt.MakeRandom(16); err != nil {
 		return
@@ -192,7 +187,7 @@ func createPasswordRec(password string, admin bool) (newRec PasswordRecord, err 
 	}
 
 	// generate a key pair
-	switch DefaultRecordType {
+	switch userType {
 	case RSARecord:
 		var rsaPriv *rsa.PrivateKey
 		rsaPriv, err = rsa.GenerateKey(rand.Reader, 2048)
@@ -217,6 +212,8 @@ func createPasswordRec(password string, admin bool) (newRec PasswordRecord, err 
 		newRec.ECKey.ECPublic.Curve = ecPriv.PublicKey.Curve.Params()
 		newRec.ECKey.ECPublic.X = ecPriv.PublicKey.X
 		newRec.ECKey.ECPublic.Y = ecPriv.PublicKey.Y
+	default:
+		err = errors.New("Unknown record type")
 	}
 
 	newRec.Admin = admin
@@ -257,14 +254,18 @@ func encryptECB(data, key []byte) (encryptedData []byte, err error) {
 }
 
 // InitFromDisk reads the record from disk and initialize global context.
-func InitFromDisk(path string) error {
-	jsonDiskRecord, err := ioutil.ReadFile(path)
+func InitFrom(path string) (records Records, err error) {
+	var jsonDiskRecord []byte
 
-	// It's OK for the file to be missing, we'll create it later if
-	// anything is added.
+	if path != "memory" {
+		jsonDiskRecord, err = ioutil.ReadFile(path)
 
-	if err != nil && !os.IsNotExist(err) {
-		return err
+		// It's OK for the file to be missing, we'll create it later if
+		// anything is added.
+
+		if err != nil && !os.IsNotExist(err) {
+			return
+		}
 	}
 
 	// Initialized so that we can determine later if anything was read
@@ -274,47 +275,47 @@ func InitFromDisk(path string) error {
 
 	if len(jsonDiskRecord) != 0 {
 		if err = json.Unmarshal(jsonDiskRecord, &records); err != nil {
-			return err
+			return
 		}
 	}
 
-	formatErr := errors.New("Format error")
+	err = errors.New("Format error")
 	for _, rec := range records.Passwords {
 		if len(rec.PasswordSalt) != 16 {
-			return formatErr
+			return
 		}
 		if len(rec.HashedPassword) != 16 {
-			return formatErr
+			return
 		}
 		if len(rec.KeySalt) != 16 {
-			return formatErr
+			return
 		}
 		if rec.Type == RSARecord {
 			if len(rec.RSAKey.RSAExp) == 0 || len(rec.RSAKey.RSAExp)%16 != 0 {
-				return formatErr
+				return
 			}
 			if len(rec.RSAKey.RSAPrimeP) == 0 || len(rec.RSAKey.RSAPrimeP)%16 != 0 {
-				return formatErr
+				return
 			}
 			if len(rec.RSAKey.RSAPrimeQ) == 0 || len(rec.RSAKey.RSAPrimeQ)%16 != 0 {
-				return formatErr
+				return
 			}
 			if len(rec.RSAKey.RSAExpIV) != 16 {
-				return formatErr
+				return
 			}
 			if len(rec.RSAKey.RSAPrimePIV) != 16 {
-				return formatErr
+				return
 			}
 			if len(rec.RSAKey.RSAPrimeQIV) != 16 {
-				return formatErr
+				return
 			}
 		}
 		if rec.Type == ECCRecord {
 			if len(rec.ECKey.ECPriv) == 0 || len(rec.ECKey.ECPriv)%16 != 0 {
-				return formatErr
+				return
 			}
 			if len(rec.ECKey.ECPrivIV) != 16 {
-				return formatErr
+				return
 			}
 		}
 	}
@@ -327,62 +328,53 @@ func InitFromDisk(path string) error {
 		records.VaultId = int(mrand.Int31())
 		records.HmacKey, err = symcrypt.MakeRandom(16)
 		if err != nil {
-			return err
+			return
 		}
 		records.Passwords = make(map[string]PasswordRecord)
 	}
 
-	localPath = path
+	records.localPath = path
 
-	return nil
+	err = nil
+	return
 }
 
 // WriteRecordsToDisk saves the current state of the records to disk.
-func WriteRecordsToDisk() error {
-	if !IsInitialized() {
-		return errors.New("Path not initialized")
+func (records *Records) WriteRecordsToDisk() error {
+	if records.localPath == "memory" {
+		return nil
+	} else {
+		jsonDiskRecord, err := json.Marshal(records)
+		if err != nil {
+			return err
+		}
+		return ioutil.WriteFile(records.localPath, jsonDiskRecord, 0644)
 	}
-
-	jsonDiskRecord, err := json.Marshal(records)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(localPath, jsonDiskRecord, 0644)
 }
 
 // AddNewRecord adds a new record for a given username and password.
-func AddNewRecord(name, password string, admin bool) (PasswordRecord, error) {
-	pr, err := createPasswordRec(password, admin)
+func (records *Records) AddNewRecord(name, password string, admin bool, userType string) (PasswordRecord, error) {
+	pr, err := createPasswordRec(password, admin, userType)
 	if err != nil {
 		return pr, err
 	}
-	SetRecord(pr, name)
-	return pr, WriteRecordsToDisk()
+	records.SetRecord(pr, name)
+	return pr, records.WriteRecordsToDisk()
 }
 
 // ChangePassword changes the password for a given user.
-func ChangePassword(name, password, newPassword string) (err error) {
-	pr, ok := GetRecord(name)
+func (records *Records) ChangePassword(name, password, newPassword string) (err error) {
+	pr, ok := records.GetRecord(name)
 	if !ok {
 		err = errors.New("Record not present")
 		return
 	}
-	if err = pr.ValidatePassword(password); err != nil {
-		return
-	}
 
-	// add the password salt and hash
-	if pr.PasswordSalt, err = symcrypt.MakeRandom(16); err != nil {
+	var keySalt []byte
+	if keySalt, err = symcrypt.MakeRandom(16); err != nil {
 		return
 	}
-	if pr.HashedPassword, err = hashPassword(newPassword, pr.PasswordSalt); err != nil {
-		return
-	}
-
-	if pr.KeySalt, err = symcrypt.MakeRandom(16); err != nil {
-		return
-	}
-	newPassKey, err := derivePasswordKey(newPassword, pr.KeySalt)
+	newPassKey, err := derivePasswordKey(newPassword, keySalt)
 	if err != nil {
 		return
 	}
@@ -417,84 +409,81 @@ func ChangePassword(name, password, newPassword string) (err error) {
 		return
 	}
 
-	SetRecord(pr, name)
+	// add the password salt and hash
+	if pr.PasswordSalt, err = symcrypt.MakeRandom(16); err != nil {
+		return
+	}
+	if pr.HashedPassword, err = hashPassword(newPassword, pr.PasswordSalt); err != nil {
+		return
+	}
 
-	return WriteRecordsToDisk()
+	pr.KeySalt = keySalt
+
+	records.SetRecord(pr, name)
+
+	return records.WriteRecordsToDisk()
 }
 
 // DeleteRecord deletes a given record.
-func DeleteRecord(name string) error {
-	if _, ok := GetRecord(name); ok {
+func (records *Records) DeleteRecord(name string) error {
+	if _, ok := records.GetRecord(name); ok {
 		delete(records.Passwords, name)
-		return WriteRecordsToDisk()
+		return records.WriteRecordsToDisk()
 	} else {
 		return errors.New("Record missing")
 	}
 }
 
 // RevokeRecord removes admin status from a record.
-func RevokeRecord(name string) error {
-	if rec, ok := GetRecord(name); ok {
+func (records *Records) RevokeRecord(name string) error {
+	if rec, ok := records.GetRecord(name); ok {
 		rec.Admin = false
-		SetRecord(rec, name)
-		return WriteRecordsToDisk()
+		records.SetRecord(rec, name)
+		return records.WriteRecordsToDisk()
 	} else {
 		return errors.New("Record missing")
 	}
 }
 
 // MakeAdmin adds admin status to a given record.
-func MakeAdmin(name string) error {
-	if rec, ok := GetRecord(name); ok {
+func (records *Records) MakeAdmin(name string) error {
+	if rec, ok := records.GetRecord(name); ok {
 		rec.Admin = true
-		SetRecord(rec, name)
-		return WriteRecordsToDisk()
+		records.SetRecord(rec, name)
+		return records.WriteRecordsToDisk()
 	} else {
 		return errors.New("Record missing")
 	}
 }
 
 // SetRecord puts a record into the global status.
-func SetRecord(pr PasswordRecord, name string) {
+func (records *Records) SetRecord(pr PasswordRecord, name string) {
 	records.Passwords[name] = pr
 }
 
 // GetRecord returns a record given a name.
-func GetRecord(name string) (PasswordRecord, bool) {
+func (records *Records) GetRecord(name string) (PasswordRecord, bool) {
 	dpr, found := records.Passwords[name]
 	return dpr, found
 }
 
 // GetVaultId returns the id of the current vault.
-func GetVaultId() (id int, err error) {
-	if !IsInitialized() {
-		return 0, errors.New("Path not initialized")
-	} else {
-		return records.VaultId, nil
-	}
+func (records *Records) GetVaultId() (id int, err error) {
+	return records.VaultId, nil
 }
 
 // GetHmacKey returns the hmac key of the current vault.
-func GetHmacKey() (key []byte, err error) {
-	if !IsInitialized() {
-		return nil, errors.New("Path not initialized")
-	} else {
-		return records.HmacKey, nil
-	}
-}
-
-// IsInitialized returns true if the disk vault has been loaded.
-func IsInitialized() bool {
-	return localPath != ""
+func (records *Records) GetHmacKey() (key []byte, err error) {
+	return records.HmacKey, nil
 }
 
 // NumRecords returns the number of records in the vault.
-func NumRecords() int {
+func (records *Records) NumRecords() int {
 	return len(records.Passwords)
 }
 
 // GetSummary returns a summary of the records on disk.
-func GetSummary() (summary map[string]Summary) {
+func (records *Records) GetSummary() (summary map[string]Summary) {
 	summary = make(map[string]Summary)
 	for name, pass := range records.Passwords {
 		summary[name] = Summary{pass.Admin, pass.Type}
@@ -503,17 +492,17 @@ func GetSummary() (summary map[string]Summary) {
 }
 
 // IsAdmin returns the admin status of the PasswordRecord.
-func (pr PasswordRecord) IsAdmin() bool {
+func (pr *PasswordRecord) IsAdmin() bool {
 	return pr.Admin
 }
 
 // GetType returns the type status of the PasswordRecord.
-func (pr PasswordRecord) GetType() string {
+func (pr *PasswordRecord) GetType() string {
 	return pr.Type
 }
 
 // EncryptKey encrypts a 16-byte key with the RSA or EC key of the record.
-func (pr PasswordRecord) EncryptKey(in []byte) (out []byte, err error) {
+func (pr *PasswordRecord) EncryptKey(in []byte) (out []byte, err error) {
 	if pr.Type == RSARecord {
 		return rsa.EncryptOAEP(sha1.New(), rand.Reader, &pr.RSAKey.RSAPublic, in, nil)
 	} else if pr.Type == ECCRecord {
@@ -524,7 +513,7 @@ func (pr PasswordRecord) EncryptKey(in []byte) (out []byte, err error) {
 }
 
 // GetKeyRSAPub returns the RSA public key of the record.
-func (pr PasswordRecord) GetKeyRSAPub() (out *rsa.PublicKey, err error) {
+func (pr *PasswordRecord) GetKeyRSAPub() (out *rsa.PublicKey, err error) {
 	if pr.Type != RSARecord {
 		return out, errors.New("Invalid function for record type")
 	} else {
@@ -533,7 +522,7 @@ func (pr PasswordRecord) GetKeyRSAPub() (out *rsa.PublicKey, err error) {
 }
 
 // GetKeyECCPub returns the ECDSA public key out of the record.
-func (pr PasswordRecord) GetKeyECCPub() (out *ecdsa.PublicKey, err error) {
+func (pr *PasswordRecord) GetKeyECCPub() (out *ecdsa.PublicKey, err error) {
 	if pr.Type != ECCRecord {
 		return out, errors.New("Invalid function for record type")
 	} else {
@@ -542,7 +531,7 @@ func (pr PasswordRecord) GetKeyECCPub() (out *ecdsa.PublicKey, err error) {
 }
 
 // GetKeyECC returns the ECDSA private key of the record given the correct password.
-func (pr PasswordRecord) GetKeyECC(password string) (key *ecdsa.PrivateKey, err error) {
+func (pr *PasswordRecord) GetKeyECC(password string) (key *ecdsa.PrivateKey, err error) {
 	if pr.Type != ECCRecord {
 		return key, errors.New("Invalid function for record type")
 	}
@@ -569,7 +558,7 @@ func (pr PasswordRecord) GetKeyECC(password string) (key *ecdsa.PrivateKey, err 
 }
 
 // GetKeyRSA returns the RSA private key of the record given the correct password.
-func (pr PasswordRecord) GetKeyRSA(password string) (key rsa.PrivateKey, err error) {
+func (pr *PasswordRecord) GetKeyRSA(password string) (key rsa.PrivateKey, err error) {
 	if pr.Type != RSARecord {
 		return key, errors.New("Invalid function for record type")
 	}
@@ -626,7 +615,7 @@ func (pr PasswordRecord) GetKeyRSA(password string) (key rsa.PrivateKey, err err
 }
 
 // ValidatePassword returns an error if the password is incorrect.
-func (pr PasswordRecord) ValidatePassword(password string) error {
+func (pr *PasswordRecord) ValidatePassword(password string) error {
 	h, err := hashPassword(password, pr.PasswordSalt)
 	if err != nil {
 		return err

--- a/passvault/passvault.go
+++ b/passvault/passvault.go
@@ -465,12 +465,12 @@ func (records *Records) GetRecord(name string) (PasswordRecord, bool) {
 }
 
 // GetVaultId returns the id of the current vault.
-func (records *Records) GetVaultId() (id int, err error) {
+func (records *Records) GetVaultID() (id int, err error) {
 	return records.VaultId, nil
 }
 
 // GetHmacKey returns the hmac key of the current vault.
-func (records *Records) GetHmacKey() (key []byte, err error) {
+func (records *Records) GetHMACKey() (key []byte, err error) {
 	return records.HmacKey, nil
 }
 

--- a/passvault/passvault_test.go
+++ b/passvault/passvault_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 func TestStaticVault(t *testing.T) {
-	// Initial create.
-	records, err := InitFrom("/tmp/redoctober.jso")
+	// Creates a temporary on-disk database to test if passvault can read and
+	// write from/to disk.  It's deleted at the bottom of the function--this
+	// should be the only test that requires touching disk.
+	records, err := InitFrom("/tmp/redoctober.json")
 	if err != nil {
 		t.Fatalf("Error reading record")
 	}
@@ -27,7 +29,6 @@ func TestStaticVault(t *testing.T) {
 		t.Fatalf("Error reading record")
 	}
 
-	// Cleaning.
 	os.Remove("/tmp/redoctober.json")
 }
 

--- a/redoctober.go
+++ b/redoctober.go
@@ -732,7 +732,7 @@ var indexHtml = []byte(`<!DOCTYPE html>
 					data : data,
 					success : function(d){
 					d = JSON.parse(window.atob(d.Response));
-					$form.find('.feedback').empty().append( makeAlert({ type: 'success', message: '<p>Successfully decrypted data:</p><pre>'+ window.atob(d.Data)+'</pre><p>Delegates: '+d.Delegates.sort().join(', ')+'</p>' }) );
+					$form.find('.feedback').empty().append( makeAlert({ type: (d.Secure ? 'success' : 'warning'), message: '<p>Successfully decrypted data:</p><pre>'+ window.atob(d.Data)+'</pre><p>Delegates: '+d.Delegates.sort().join(', ')+'</p>' }) );
 					}
 				});
 			});

--- a/redoctober.go
+++ b/redoctober.go
@@ -89,7 +89,7 @@ func NewServer(process chan<- userRequest, staticPath, addr, certPath, keyPath, 
 		Rand:         rand.Reader,
 		PreferServerCipherSuites: true,
 		SessionTicketsDisabled:   true,
-		MinVersion: tls.VersionTLS10,
+		MinVersion:               tls.VersionTLS10,
 	}
 
 	// If a caPath has been specified then a local CA is being used

--- a/redoctober.go
+++ b/redoctober.go
@@ -632,10 +632,12 @@ var indexHtml = []byte(`<!DOCTYPE html>
 				data.Users = data.Users.split(',');
 				for(var i=0, l=data.Users.length; i<l; i++){
 					data.Users[i] = data.Users[i].trim();
+					if (data.Users[i] == "") { data.Users.splice(i, 1); }
 				}
 				data.Labels = data.Labels.split(',');
 				for(var i=0, l=data.Labels.length; i<l; i++){
 					data.Labels[i] = data.Labels[i].trim();
+					if (data.Labels[i] == "") { data.Labels.splice(i, 1); }
 				}
 
 				submit( $form, {
@@ -701,10 +703,12 @@ var indexHtml = []byte(`<!DOCTYPE html>
 				data.Owners = data.Owners.split(',');
 				for(var i=0, l=data.Owners.length; i<l; i++){
 					data.Owners[i] = data.Owners[i].trim();
+					if (data.Owners[i] == "") { data.Owners.splice(i, 1); }
 				}
 				data.Labels = data.Labels.split(',');
 				for(var i=0, l=data.Labels.length; i<l; i++){
 					data.Labels[i] = data.Labels[i].trim();
+					if (data.Labels[i] == "") { data.Labels.splice(i, 1); }
 				}
 
 				// Convert data to base64.


### PR DESCRIPTION
Change Summary:
- Removed the AES user type and pruned a lot of code that was working around it.
  - Delegated key usage now decrements *more* correctly.  (It's still incorrect, though.)
- Removed global state in most modules.
- When creating a user, added the choice of user type.  (Necessary to reduce global state.)
- Patched UX bug where empty coma-delimited lists would be parsed as [""].
- Added option to initialize a new passvault in-memory only.
  - Lowered disk thrashing in unit tests by switching to in-memory vaults (except when the ability to read from disk was the test object).
- Patched malleability in HMAC by adding a transparent integrity layer that authenticates the message's *structure*.  (Currently adversaries can modify messages without detection.)
  - Added a `Secure` tag to decrypt queries to tell users if they're getting an encryption from a secure or insecure version without breaking backwards compatibility.
- Rewrote key wrapping code in a more natural way.

The commits have already been squashed into natural sub-divisions of work, but I'll squash it further if wanted.  Thank you!