### PR TITLE
Add support for listing required delegations for an encrypted secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ format is POSTed and JSON is returned.
  - `/modify`: Modify permissions
  - `/encrypt`: Encrypt
  - `/decrypt`: Decrypt
+ - `/owners`: List owners of an encrypted secret.
  - `/summary`: Display summary of the delegates
  - `/password`: Change password
  - `/index`: Optionally, the server can host a static HTML file.
@@ -177,6 +178,17 @@ Example query:
 If there aren't enough keys delegated you'll see:
 
     {"Status":"Need more delegated keys"}
+
+### Owners
+
+Owners allows users to determine which delegations are needed to decrypt
+a piece of data.
+
+Example query:
+
+    $ curl --cacert cert/server.crt https://localhost:8080/owners  \
+            -d '{"Data":"eyJWZXJzaW9uIj...NSSllzPSJ9"}'
+    {"Status":"ok","Owners":["Alice","Bill","Cat","Dodo"]}
 
 ### Password
 

--- a/core/core.go
+++ b/core/core.go
@@ -73,6 +73,10 @@ type DecryptRequest struct {
 	Data []byte
 }
 
+type OwnersRequest struct {
+	Data []byte
+}
+
 type ModifyRequest struct {
 	Name     string
 	Password string
@@ -98,6 +102,11 @@ type DecryptWithDelegates struct {
 	Data      []byte
 	Secure    bool
 	Delegates []string
+}
+
+type OwnersData struct {
+	Status string
+	Owners []string
 }
 
 // Helper functions that create JSON responses sent by core
@@ -365,4 +374,22 @@ func Modify(jsonIn []byte) ([]byte, error) {
 	} else {
 		return jsonStatusOk()
 	}
+}
+
+// Owners processes a owners request.
+func Owners(jsonIn []byte) ([]byte, error) {
+	var s OwnersRequest
+	err := json.Unmarshal(jsonIn, &s)
+	if err != nil {
+		log.Println("Error unmarshaling input:", err)
+		return jsonStatusError(err)
+	}
+
+	names, err := crypt.GetOwners(s.Data)
+	if err != nil {
+		log.Println("Error listing owners:", err)
+		return jsonStatusError(err)
+	}
+
+	return json.Marshal(OwnersData{Status: "ok", Owners: names})
 }

--- a/redoctober.go
+++ b/redoctober.go
@@ -33,6 +33,7 @@ var functions = map[string]func([]byte) ([]byte, error){
 	"/password": core.Password,
 	"/encrypt":  core.Encrypt,
 	"/decrypt":  core.Decrypt,
+	"/owners":   core.Owners,
 	"/modify":   core.Modify,
 }
 
@@ -273,6 +274,7 @@ var indexHtml = []byte(`<!DOCTYPE html>
 					<li><a href="#admin">Admin</a></li>
 					<li><a href="#encrypt">Encrypt</a></li>
 					<li><a href="#decrypt">Decrypt</a></li>
+					<li><a href="#owners">Owners</a></li>
 				</ul>
 			</div>
 		</div>
@@ -528,6 +530,22 @@ var indexHtml = []byte(`<!DOCTYPE html>
 				</form>
 			</div>
 		</section>
+		<hr />
+		<section class="row">
+			<div id="owners" class="col-md-6">
+				<h3>Get Owners</h3>
+
+				<form id="owners" class="ro-user-owners" role="form" action="/owners" method="post">
+					<div class="feedback owners-feedback"></div>
+
+					<div class="form-group">
+						<label for="owners-data">Data</label>
+						<textarea name="Data" class="form-control" id="owners-data" rows="5" required></textarea>
+					</div>
+					<button type="submit" class="btn btn-primary">Get Owners</button>
+				</form>
+			</div>
+		</section>
 	</div>
 
 	<footer id="footer" class="footer">
@@ -734,6 +752,20 @@ var indexHtml = []byte(`<!DOCTYPE html>
 					success : function(d){
 					d = JSON.parse(window.atob(d.Response));
 					$form.find('.feedback').empty().append( makeAlert({ type: (d.Secure ? 'success' : 'warning'), message: '<p>Successfully decrypted data:</p><pre>'+ window.atob(d.Data)+'</pre><p>Delegates: '+d.Delegates.sort().join(', ')+'</p>' }) );
+					}
+				});
+			});
+
+			// Get owners
+			$('body').on('submit', 'form#owners', function(evt){
+				evt.preventDefault();
+				var $form = $(evt.currentTarget),
+					data = serialize($form);
+
+				submit( $form, {
+					data : data,
+					success : function(d){
+					$form.find('.feedback').empty().append( makeAlert({ type: 'success', message: '<p>Owners: '+d.Owners.sort().join(', ')+'</p>' }) );
 					}
 				});
 			});


### PR DESCRIPTION
This patch adds the /owners API endpoint that returns the list of users
that "own" the given secret. These are the users that can delegate their
passwords for decrypting the secret.

It also adds the "Get Owners" form in the web UI that uses the new API.

Fixes #62