### PR TITLE
Add export endpoint, permitting backing up the vault.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -85,6 +85,11 @@ type ModifyRequest struct {
 	Command  string
 }
 
+type ExportRequest struct {
+	Name     string
+	Password string
+}
+
 // These structures map the JSON responses that will be sent from the API
 
 type ResponseData struct {
@@ -394,4 +399,28 @@ func Owners(jsonIn []byte) ([]byte, error) {
 	}
 
 	return json.Marshal(OwnersData{Status: "ok", Owners: names})
+}
+
+// Export returns a backed up vault.
+func Export(jsonIn []byte) ([]byte, error) {
+	var req ExportRequest
+	err := json.Unmarshal(jsonIn, &req)
+	if err != nil {
+		log.Println("Error unmarshaling input:", err)
+		return jsonStatusError(err)
+	}
+
+	err = validateUser(req.Name, req.Password, true)
+	if err != nil {
+		log.Println("Unauthorized attempt to export disk records")
+		return jsonStatusError(err)
+	}
+
+	out, err := json.Marshal(records)
+	if err != nil {
+		log.Println("Error exporting vault:", err)
+		return jsonStatusError(err)
+	}
+
+	return jsonResponse(out)
 }

--- a/redoctober.go
+++ b/redoctober.go
@@ -35,6 +35,7 @@ var functions = map[string]func([]byte) ([]byte, error){
 	"/decrypt":  core.Decrypt,
 	"/owners":   core.Owners,
 	"/modify":   core.Modify,
+	"/export":   core.Export,
 }
 
 type userRequest struct {


### PR DESCRIPTION
This permits backing up the disk records via the API. This hasn't been added to the UI yet, as this requires someone who actually knows JavaScript.

The admin user will be able to export the records. These are considered not secret, as they are encrypted properly using a key derived using Scrypt.