### PR TITLE
Migrate Travis to containerised builds; bump Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ notifications:
     recipients:
       - nick@cloudflare.com
       - kyle@cloudflare.com
+      - zi@cloudflare.com
     on_success: never
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+sudo: false
 language: go
-go: 1.2
+go: 1.4
 script:
   - go get golang.org/x/tools/cmd/vet
   - go get github.com/cloudflare/redoctober


### PR DESCRIPTION
- Migrate Travis: see http://docs.travis-ci.com/user/migrating-from-legacy/
- Bump Go version from 1.2 to 1.4: Go 1.2 is outdated