### PR TITLE
Add new operation: re-encrypt

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -189,6 +189,21 @@ func (c *RemoteServer) Encrypt(req core.EncryptRequest) (*core.ResponseData, err
 	return unmarshalResponseData(respBytes)
 }
 
+// ReEncrypt issues an re-encrypt request to the remote server
+func (c *RemoteServer) ReEncrypt(req core.ReEncryptRequest) (*core.ResponseData, error) {
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	respBytes, err := c.doAction("re-encrypt", reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalResponseData(respBytes)
+}
+
 // Decrypt issues an decrypt request to the remote server
 func (c *RemoteServer) Decrypt(req core.DecryptRequest) (*core.ResponseData, error) {
 	reqBytes, err := json.Marshal(req)

--- a/redoctober.go
+++ b/redoctober.go
@@ -27,16 +27,17 @@ import (
 // List of URLs to register and their related functions
 
 var functions = map[string]func([]byte) ([]byte, error){
-	"/create":   core.Create,
-	"/summary":  core.Summary,
-	"/purge":    core.Purge,
-	"/delegate": core.Delegate,
-	"/password": core.Password,
-	"/encrypt":  core.Encrypt,
-	"/decrypt":  core.Decrypt,
-	"/owners":   core.Owners,
-	"/modify":   core.Modify,
-	"/export":   core.Export,
+	"/create":     core.Create,
+	"/summary":    core.Summary,
+	"/purge":      core.Purge,
+	"/delegate":   core.Delegate,
+	"/password":   core.Password,
+	"/encrypt":    core.Encrypt,
+	"/re-encrypt": core.ReEncrypt,
+	"/decrypt":    core.Decrypt,
+	"/owners":     core.Owners,
+	"/modify":     core.Modify,
+	"/export":     core.Export,
 }
 
 type userRequest struct {


### PR DESCRIPTION
're-encrypt' allows us to re-encrypt an RO encryption to a different set
of owners and labels. Currently two delegations are sufficient to carry
out this operation.