### PR TITLE
Upadte README to specify Go 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ encryption and decryption server.
 
 [![Build Status](https://travis-ci.org/cloudflare/redoctober.png?branch=master)](https://travis-ci.org/cloudflare/redoctober) [![Build Status](https://drone.io/github.com/cloudflare/redoctober/status.png)](https://drone.io/github.com/cloudflare/redoctober/latest)[![Coverage Status](http://codecov.io/github/cloudflare/redoctober/coverage.svg?branch=master)](http://codecov.io/github/cloudflare/redoctober?branch=master)
 
-This project requires [Go 1.2](http://golang.org/doc/install#download)
+This project requires [Go 1.4](http://golang.org/doc/install#download)
 or later to compile. Verify your go version by running `go version`:
 
     $ go version
-    go version go1.2
+    go version go1.4
 
 As with any Go program you do need to set the
 [GOPATH enviroment variable](http://golang.org/doc/code.html#GOPATH)


### PR DESCRIPTION
`os.Unsetenv` is used which requires Go 1.4