### PR TITLE
Fix "invalid key size 0" when decrypting after a delegation expires

### DIFF
--- a/keycache/keycache_test.go
+++ b/keycache/keycache_test.go
@@ -70,7 +70,6 @@ func TestUsesFlush(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	cache.Refresh()
 	if len(cache.UserKeys) != 0 {
 		t.Fatalf("Error in number of live keys %v", cache.UserKeys)
 	}


### PR DESCRIPTION
The keycache does not remove active delegations when uses drops to zero;
rather it only removes these when Refresh is called.

So Valid returns true even if the user's delegation has expired,
so fullMatch is not set to false in unwrapKey,
so DecryptKey fails since the keycache refreshes and finds the delegation has expired,
so tmpKeyValue is left empty and decryptErr is set.

Since decryptErr is only used to break out of the inner loop, and
fullMatch wasn't set to false, no error is returned from unwrapKey.
So aesKey in DecryptKey is an empty string, causing an error when
passed to aes.NewCipher.

This commit actively removes a delegation from the keycache when it
is used for the last time, and properly handles errors thrown by
DecryptKey in unwrapKey.