### PR TITLE
Rewrite MSP parsers.

### DIFF
--- a/msp/formatted_test.go
+++ b/msp/formatted_test.go
@@ -87,3 +87,17 @@ func TestFormatted(t *testing.T) {
 		t.Fatalf("Query #3 decoded wrong: %v %v", decQuery3.String(), err)
 	}
 }
+
+func TestBugs(t *testing.T) {
+	bugs := []string{
+		"(),)",
+		"((2, Alice, Bob), Bob, Carl)",
+	}
+
+	for _, bug := range bugs {
+		_, err := StringToFormatted(bug)
+		if err == nil {
+			t.Fatalf("Didn't panic or error on a malformed string: %v", bug)
+		}
+	}
+}


### PR DESCRIPTION
- Stop using container/list.  It requires casting which keeps causing panics.
- Justify all slice accesses.  Nil pointers also keep causing panics.

Closes issue #110.