### PR TITLE
Dockerize Red October

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+cert/
 pkg/
 src/code.google.com/
 *~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.6-onbuild
+
+RUN mkdir cert
+RUN chmod 700 cert
+# Generate private key with password "password"
+RUN openssl genrsa -aes128 -passout pass:password -out cert/server.pem 2048
+# Remove password from private key
+RUN openssl rsa -passin pass:password -in cert/server.pem -out cert/server.pem
+# Generate CSR (make sure the common name CN field matches your server
+# address. It's set to "localhost" here.)
+RUN openssl req -new -key cert/server.pem -out cert/server.csr -subj '/C=US/ST=California/L=Everywhere/CN=localhost'
+# Sign the CSR and create certificate
+RUN openssl x509 -req -days 365 -in cert/server.csr -signkey cert/server.pem -out cert/server.crt
+# Clean up
+RUN rm cert/server.csr
+RUN chmod 600 cert/*
+
+EXPOSE 8080
+
+CMD app \
+  -addr=localhost:8080 \
+  -vaultpath=diskrecord.json \
+  -certs=cert/server.crt \
+  -keys=cert/server.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM golang:1.6-onbuild
+FROM golang:1.6-alpine
+
+RUN apk update
+RUN apk add git
+
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+COPY . /go/src/app
+
+RUN go get -d -v
+RUN go install -v
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN ./script/generatecert
 EXPOSE 8080
 
 CMD app \
-  -addr=localhost:8080 \
+  -addr=0.0.0.0:8080 \
   -vaultpath=diskrecord.json \
   -certs=cert/server.crt \
   -keys=cert/server.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN rm -rf /var/cache/apk/*
 
 EXPOSE 8080
 
-CMD ./script/docker-start
+ENTRYPOINT ["./script/docker-start"]
+CMD ["-vaultpath=diskrecord.json", "-certs=cert/server.crt", "-keys=cert/server.pem"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM golang:1.6-alpine
 
-RUN apk update
-RUN apk add git
+RUN mkdir -p /go/src/redoctober
+WORKDIR /go/src/redoctober
 
-RUN mkdir -p /go/src/app
-WORKDIR /go/src/app
-COPY . /go/src/app
+# https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
+RUN apk --no-cache add git openssl
 
+# build binary
+COPY . /go/src/redoctober
 RUN go get -d -v
 RUN go install -v
+
+# cleanup
+RUN apk del git
+RUN rm -rf /var/cache/apk/*
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,6 @@
 FROM golang:1.6-onbuild
 
-RUN mkdir cert
-RUN chmod 700 cert
-# Generate private key with password "password"
-RUN openssl genrsa -aes128 -passout pass:password -out cert/server.pem 2048
-# Remove password from private key
-RUN openssl rsa -passin pass:password -in cert/server.pem -out cert/server.pem
-# Generate CSR (make sure the common name CN field matches your server
-# address. It's set to "localhost" here.)
-RUN openssl req -new -key cert/server.pem -out cert/server.csr -subj '/C=US/ST=California/L=Everywhere/CN=localhost'
-# Sign the CSR and create certificate
-RUN openssl x509 -req -days 365 -in cert/server.csr -signkey cert/server.pem -out cert/server.crt
-# Clean up
-RUN rm cert/server.csr
-RUN chmod 600 cert/*
-
+RUN ./script/generatecert
 EXPOSE 8080
 
 CMD app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM golang:1.6-onbuild
 
-RUN ./script/generatecert
 EXPOSE 8080
 
-CMD app \
-  -addr=0.0.0.0:8080 \
-  -vaultpath=diskrecord.json \
-  -certs=cert/server.crt \
-  -keys=cert/server.pem
+CMD ./script/docker-start

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The easiest way to try out Red October is via [Docker](https://www.docker.com/).
     git clone https://github.com/cloudflare/redoctober.git
     cd redoctober
     docker build -t redoctober .
-    docker run -i --rm -p 8080:8080 redoctober
+    docker run -it --rm -p 8080:8080 redoctober
     ```
 
 1. Open the container address in your browser.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@ And run the tests:
 Red October is a TLS server. It requires a local file to hold the key
 vault, an internet address, and a certificate keypair.
 
+### Docker
+
+***This is still a proof-of-concept, and is not yet recommended for production.***
+
+The easiest way to try out Red October is via [Docker](https://www.docker.com/).
+
+1. Install the [Docker Toolbox](https://www.docker.com/products/docker-toolbox).
+1. On Mac/Windows, open the Docker Quickstart Terminal/Shell. On Linux, your normal terminal is fine.
+1. Run
+
+    ```bash
+    git clone https://github.com/cloudflare/redoctober.git
+    cd redoctober
+    docker build -t redoctober .
+    docker run -i --rm -p 8080:8080 redoctober
+    ```
+
+1. Open the container address in your browser.
+    * Mac/Windows: In a new Docker Quickstart Terminal/Shell, run
+
+        ```bash
+        open "https://$(docker-machine ip):8080"
+        ```
+
+    * Linux: Go to [https://localhost:8080](https://localhost:8080) in your browser.
+
+### Manual
+
 First you need to acquire a TLS certificate. The simplest (and least
 secure) way is to skip the
 [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority#Issuing_a_certificate)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ vault, an internet address, and a certificate keypair.
 
 ### Docker
 
-***This is still a proof-of-concept, and is not yet recommended for production.***
+***This is only meant for demo purposes, and is not yet recommended for production.***
 
 The easiest way to try out Red October is via [Docker](https://www.docker.com/).
 
@@ -63,22 +63,9 @@ secure) way is to skip the
 [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority#Issuing_a_certificate)
 verification and generate a self-signed TLS certificate. Read this
 [detailed guide](http://www.akadia.com/services/ssh_test_certificate.html)
-or, alternatively, follow these insecure commands:
+or, alternatively, run this command to generate an insecure certificate:
 
-    $ mkdir cert
-    $ chmod 700 cert
-    ## Generate private key with password "password"
-    $ openssl genrsa -aes128 -passout pass:password -out cert/server.pem 2048
-    ## Remove password from private key
-    $ openssl rsa -passin pass:password -in cert/server.pem -out cert/server.pem
-    ## Generate CSR (make sure the common name CN field matches your server
-    ## address. It's set to "localhost" here.)
-    $ openssl req -new -key cert/server.pem -out cert/server.csr -subj '/C=US/ST=California/L=Everywhere/CN=localhost'
-    ## Sign the CSR and create certificate
-    $ openssl x509 -req -days 365 -in cert/server.csr -signkey cert/server.pem -out cert/server.crt
-    ## Clean up
-    $ rm cert/server.csr
-    $ chmod 600 cert/*
+    $ ./script/generatecert
 
 You're ready to run the server:
 

--- a/script/docker-start
+++ b/script/docker-start
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname $0)/generatecert
 
-exec app \
+exec redoctober \
   -addr=0.0.0.0:8080 \
   -vaultpath=diskrecord.json \
   -certs=cert/server.crt \

--- a/script/docker-start
+++ b/script/docker-start
@@ -4,4 +4,4 @@ set -e
 
 source $(dirname $0)/generatecert
 
-exec redoctober -addr=0.0.0.0:8080 $@
+exec redoctober -addr=:8080 $@

--- a/script/docker-start
+++ b/script/docker-start
@@ -4,8 +4,4 @@ set -e
 
 source $(dirname $0)/generatecert
 
-exec redoctober \
-  -addr=0.0.0.0:8080 \
-  -vaultpath=diskrecord.json \
-  -certs=cert/server.crt \
-  -keys=cert/server.pem
+exec redoctober -addr=0.0.0.0:8080 $@

--- a/script/docker-start
+++ b/script/docker-start
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+source $(dirname $0)/generatecert
+
+exec app \
+  -addr=0.0.0.0:8080 \
+  -vaultpath=diskrecord.json \
+  -certs=cert/server.crt \
+  -keys=cert/server.pem

--- a/script/docker-test
+++ b/script/docker-test
@@ -12,6 +12,7 @@ function cleanup {
 
 function failure {
   >&2 echo "FAILED"
+  docker logs redoctober1
   cleanup
   exit 1
 }

--- a/script/docker-test
+++ b/script/docker-test
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+function cleanup {
+  echo "Cleaning up..."
+  docker kill redoctober1 > /dev/null 2>&1 || true
+  # in case the container remains
+  docker rm redoctober1 > /dev/null 2>&1 || true
+  echo "done."
+}
+
+function failure {
+  >&2 echo "FAILED"
+  cleanup
+  exit 1
+}
+
+cleanup
+
+{
+  docker build -t redoctober . > /dev/null
+
+  docker run -d -i -p 8080:8080 --name redoctober1 redoctober > /dev/null
+  curl -I -k "https://$(docker-machine ip):8080" > /dev/null
+} || failure
+
+cleanup
+
+echo "SUCCESS"

--- a/script/generatecert
+++ b/script/generatecert
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 set -x

--- a/script/generatecert
+++ b/script/generatecert
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+set -x
+
+mkdir cert
+chmod 700 cert
+# Generate private key with password "password"
+openssl genrsa -aes128 -passout pass:password -out cert/server.pem 2048
+# Remove password from private key
+openssl rsa -passin pass:password -in cert/server.pem -out cert/server.pem
+# Generate CSR (make sure the common name CN field matches your server
+# address. It's set to "localhost" here.)
+openssl req -new -key cert/server.pem -out cert/server.csr -subj '/C=US/ST=California/L=Everywhere/CN=localhost'
+# Sign the CSR and create certificate
+openssl x509 -req -days 365 -in cert/server.csr -signkey cert/server.pem -out cert/server.crt
+# Clean up
+rm cert/server.csr
+chmod 600 cert/*

--- a/script/generatecert
+++ b/script/generatecert
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-mkdir cert
+mkdir -p cert
 chmod 700 cert
 # Generate private key with password "password"
 openssl genrsa -aes128 -passout pass:password -out cert/server.pem 2048


### PR DESCRIPTION
This pull request is meant to make getting up and running with Red October easier, and because I get a weird satisfaction in wrapping applications with Dockerfiles :wink: 

**This is still a work-in-progress**, because I'm running into a problem accessing the server from the host machine. After starting the Docker container with

```
$ docker run -i --rm -p 8080:8080 --name=redoctober1 redoctober
2016/03/02 12:49:10 core.init success: path=diskrecord.json
```

opening what _should be_ the correct address (`https://<Docker machine IP>:8080`) gives me an `ERR_CONNECTION_REFUSED`. I know the server is running, because I'm able to access it from within the container:

```
$ docker exec -it redoctober1 bash
root@ffa416e788ed:/go/src/app# curl -I --cacert cert/server.crt https://localhost:8080
HTTP/1.1 200 OK
...
```

Any ideas?

## TODOs

* [x] **Blocker:** Update instructions with fix for accessing the Docker container (described above)
* [x] Later: Allow mounting the certificate files as a volume
* [x] Later: Mount the `vaultpath` as a volume
* [ ] Later: Publish the image on Docker Hub, and simplify the instructions to use `docker pull` instead of building it locally