### PR TITLE
Add Option for Delegation to Any User

### DIFF
--- a/cmd/ro/main.go
+++ b/cmd/ro/main.go
@@ -23,6 +23,8 @@ var owners, lefters, righters, inPath, labels, outPath, outEnv string
 
 var uses, minUsers int
 
+var anyUser bool
+
 var duration, users string
 
 var pollInterval time.Duration
@@ -52,6 +54,7 @@ func registerFlags() {
 	flag.StringVar(&users, "users", "", "comma separated user list")
 	flag.IntVar(&uses, "uses", 0, "number of delegated key uses")
 	flag.IntVar(&minUsers, "minUsers", 2, "minimum number of delegations")
+	flag.BoolVar(&anyUser, "anyUser", false, "whether any user can decrypt")
 	flag.StringVar(&duration, "time", "0h", "duration of delegated key uses")
 	flag.StringVar(&lefters, "left", "", "comma separated left owners")
 	flag.StringVar(&righters, "right", "", "comma separated right owners")
@@ -110,6 +113,7 @@ func runDelegate() {
 		Time:     duration,
 		Users:    processCSL(users),
 		Labels:   processCSL(labels),
+		AnyUser:  anyUser,
 	}
 	resp, err := roServer.Delegate(req)
 	processError(err)

--- a/core/core.go
+++ b/core/core.go
@@ -404,7 +404,7 @@ func Delegate(jsonIn []byte) ([]byte, error) {
 	}
 
 	// Ensure a list of Users is given or the AnyUser flag is set
-	if s.Users == nil && s.AnyUser == false {
+	if (s.Users == nil || len(s.Users) == 0) && s.AnyUser == false {
 		err = errors.New("Must provide a list of Users or set the AnyUser flag to true")
 		return jsonStatusError(err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -402,9 +402,15 @@ func Delegate(jsonIn []byte) ([]byte, error) {
 			return jsonStatusError(err)
 		}
 	}
+
+	// Ensure a list of Users is given or the AnyUser flag is set
+	if s.Users == nil && s.AnyUser == false {
+		err = errors.New("Must provide a list of Users or set the AnyUser flag to true")
+		return jsonStatusError(err)
+	}
+
 	// Find password record for user and verify that their password
 	// matches. If not found then add a new entry for this user.
-
 	pr, found := records.GetRecord(s.Name)
 	if found {
 		if err = pr.ValidatePassword(s.Password); err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -403,12 +403,6 @@ func Delegate(jsonIn []byte) ([]byte, error) {
 		}
 	}
 
-	// Ensure a list of Users is given or the AnyUser flag is set
-	if (s.Users == nil || len(s.Users) == 0) && s.AnyUser == false {
-		err = errors.New("Must provide a list of Users or set the AnyUser flag to true")
-		return jsonStatusError(err)
-	}
-
 	// Find password record for user and verify that their password
 	// matches. If not found then add a new entry for this user.
 	pr, found := records.GetRecord(s.Name)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -50,7 +50,7 @@ func TestCreate(t *testing.T) {
 
 func TestSummary(t *testing.T) {
 	createJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\"}")
-	delegateJson := []byte("{\"Name\":\"Bob\",\"Password\":\"Rob\",\"Time\":\"2h\",\"Uses\":1}")
+	delegateJson := []byte("{\"Name\":\"Bob\",\"Password\":\"Rob\",\"Time\":\"2h\",\"Uses\":1,\"AnyUser\":true}")
 
 	// check for summary of uninitialized vault
 	respJson, err := Summary(createJson)
@@ -287,9 +287,9 @@ func TestCreateUser(t *testing.T) {
 
 func TestPassword(t *testing.T) {
 	createJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\"}")
-	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"2h\",\"Uses\":1}")
+	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"2h\",\"Uses\":1,\"AnyUser\":true}")
 	passwordJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"NewPassword\":\"Olleh\"}")
-	delegateJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Olleh\",\"Time\":\"2h\",\"Uses\":1}")
+	delegateJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Olleh\",\"Time\":\"2h\",\"Uses\":1,\"AnyUser\":true}")
 	passwordJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Olleh\",\"NewPassword\":\"Hello\"}")
 
 	Init("memory", "", "", "", "")
@@ -395,12 +395,12 @@ func TestPassword(t *testing.T) {
 
 func TestEncryptDecrypt(t *testing.T) {
 	summaryJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\"}")
-	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
-	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
-	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
+	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
+	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
+	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
 	delegateJson4 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"10s\",\"Uses\":2,\"Users\":[\"Alice\"],\"Labels\":[\"blue\"]}")
 	delegateJson5 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"10s\",\"Uses\":2,\"Users\":[\"Alice\"],\"Labels\":[\"blue\"]}")
-	delegateJson6 := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"10s\",\"Uses\":1}")
+	delegateJson6 := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"10s\",\"Uses\":1,\"AnyUser\":true}")
 	encryptJson := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Minimum\":2,\"Owners\":[\"Alice\",\"Bob\",\"Carol\"],\"Data\":\"SGVsbG8gSmVsbG8=\"}")
 	encryptJson2 := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Minimum\":2,\"Owners\":[\"Alice\",\"Bob\",\"Carol\"],\"Data\":\"SGVsbG8gSmVsbG8=\",\"Labels\":[\"blue\",\"red\"]}")
 	encryptJson3 := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Minimum\":1,\"Owners\":[\"Alice\"],\"Data\":\"SGVsbG8gSmVsbG8=\"}")
@@ -623,9 +623,9 @@ func TestEncryptDecrypt(t *testing.T) {
 }
 
 func TestReEncrypt(t *testing.T) {
-	delegateJson := []byte(`{"Name":"Alice","Password":"Hello","Time":"0s","Uses":0}`)
-	delegateJson2 := []byte(`{"Name":"Bob","Password":"Hello","Time":"0s","Uses":0}`)
-	delegateJson3 := []byte(`{"Name":"Carol","Password":"Hello","Time":"0s","Uses":0}`)
+	delegateJson := []byte(`{"Name":"Alice","Password":"Hello","Time":"0s","Uses":0,"AnyUser":true}`)
+	delegateJson2 := []byte(`{"Name":"Bob","Password":"Hello","Time":"0s","Uses":0,"AnyUser":true}`)
+	delegateJson3 := []byte(`{"Name":"Carol","Password":"Hello","Time":"0s","Uses":0,"AnyUser":true}`)
 	delegateJson4 := []byte(`{"Name":"Bob","Password":"Hello","Time":"10s","Uses":2,"Users":["Alice"],"Labels":["blue"]}`)
 	delegateJson5 := []byte(`{"Name":"Carol","Password":"Hello","Time":"10s","Uses":2,"Users":["Alice"],"Labels":["blue"]}`)
 	delegateJson6 := []byte(`{"Name":"Bob","Password":"Hello","Time":"10s","Uses":2,"Users":["Alice"],"Labels":["red"]}`)
@@ -804,9 +804,9 @@ func TestReEncrypt(t *testing.T) {
 }
 
 func TestOwners(t *testing.T) {
-	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
-	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
-	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
+	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
+	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
+	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
 	encryptJson := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Minimum\":2,\"Owners\":[\"Alice\",\"Bob\",\"Carol\"],\"Data\":\"SGVsbG8gSmVsbG8=\"}")
 
 	var s ResponseData
@@ -859,9 +859,9 @@ func TestOwners(t *testing.T) {
 func TestModify(t *testing.T) {
 	summaryJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\"}")
 	summaryJson2 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\"}")
-	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
-	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
-	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0}")
+	delegateJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
+	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
+	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"Time\":\"0s\",\"Uses\":0,\"AnyUser\":true}")
 	modifyJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"ToModify\":\"Alice\",\"Command\":\"admin\"}")
 	modifyJson2 := []byte("{\"Name\":\"Carol\",\"Password\":\"Hello\",\"ToModify\":\"Alice\",\"Command\":\"revoke\"}")
 	modifyJson3 := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"ToModify\":\"Carol\",\"Command\":\"admin\"}")
@@ -1040,8 +1040,8 @@ func TestModify(t *testing.T) {
 
 func TestStatic(t *testing.T) {
 	expected := []byte("this is a secret string, shhhhhhhh. don't tell anyone, ok? whatever you do, don't tell the cops\n")
-	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Rob\",\"Time\":\"1m\",\"Uses\":5}")
-	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"~~~222\",\"Time\":\"1h\",\"Uses\":30}")
+	delegateJson2 := []byte("{\"Name\":\"Bob\",\"Password\":\"Rob\",\"Time\":\"1m\",\"Uses\":5,\"AnyUser\":true}")
+	delegateJson3 := []byte("{\"Name\":\"Carol\",\"Password\":\"~~~222\",\"Time\":\"1h\",\"Uses\":30,\"AnyUser\":true}")
 	decryptJson := []byte("{\"Name\":\"Alice\",\"Password\":\"Hello\",\"Data\":\"eyJWZXJzaW9uIjoxLCJWYXVsdElkIjo1Mjk4NTM4OTU3NzU0NTQwODEwLCJLZXlTZXQiOlt7Ik5hbWUiOlsiQm9iIiwiQWxpY2UiXSwiS2V5IjoiMmozdEkyUEJGQmJ3RlgwQmxRZFV1QT09In0seyJOYW1lIjpbIkJvYiIsIkNhcm9sIl0sIktleSI6InlMU1NCL1U2KzVyYzFFK2dqR1hUNHc9PSJ9LHsiTmFtZSI6WyJBbGljZSIsIkJvYiJdLCJLZXkiOiJERGxXSEY3c3p6SVN1WFdhRXo4bGxRPT0ifSx7Ik5hbWUiOlsiQWxpY2UiLCJDYXJvbCJdLCJLZXkiOiJUa0ExM2FQcllGTmJ2ZUlibDBxZHd3PT0ifSx7Ik5hbWUiOlsiQ2Fyb2wiLCJCb2IiXSwiS2V5IjoiS1htMHVPYm1SSjJadlNZRVdQd2syQT09In0seyJOYW1lIjpbIkNhcm9sIiwiQWxpY2UiXSwiS2V5IjoiTDljK1BxdHhQaDl5NmFwUnZ0YkNRdz09In1dLCJLZXlTZXRSU0EiOnsiQWxpY2UiOnsiS2V5IjoiZmo1bXFucTd5NUtDYWZDR1QxSTUxeEk1SnNYNzQ2KzlUVFNzcC84eWJmM2laamhGelNsd1AzYU5tc094M1NVS1RtWmxmcytiK01lRDRlS0oydUtCRnpRSEFJUE8wZndvaUNES0hoS0g2S3NvbE5xNCtqZ3BrTEFNT0xzUUdzOGc2QmhKeTZiQ0ZSalpWYzNJZGxRQUJQTTZQa1RidVN2S2huOWF0REZ3WlFENVRKQklTaTdkMmh3NExyYWR0TElUYk5xd2lGTVRRUTkrcHNYenlhdlk4SDNMTkhLR2dmNU9kN0lwdGhFUVBDSGk0bnc3WC9ZVlJURU1mb0lWY01jS093WWpsQzQ1L1ZKRUhLOVp5M0RTaUxCemptcjU3WU5JVmp3OFlaWTVER0JXcWJndTUxUlViSWNycXlMcGhCaFhvQlJ1NFIreXJoeWdCTldidmtraWZBPT0ifSwiQm9iIjp7IktleSI6IkhUWWlaMThzZjcyMWNBTjFMUk5rSi8rTDRBS1dpbE1ya015TmlCaldjbDlIUlRWUE5YSVRxUUJYZDBmQmdnR05QaVpyNlZRVHlTSzRaRnZKS0dER2l6MTdUZS9Ub0RuOFlrL0I5Y3FNc041ZkhvUXRYdmw4SVpvMndpb0E2N2NjQUoxZ0hNTU5wUHlMZEY0M1NRcWdJK1hhUTJsTVNZTE1meHhEbUJCT1ExU1dBdG8wQkRSZG5zcXB3VXdJUEtROVkzLzFvc21yakxtSm9BQzNNUHBsZXhZV2hleE53SnRTZCttRmRWWjNRZTR4OVJzUkhjTi9teWloT3QvNjdWNjBxenMxM0YwUlprTVNEemo1RGRnKzFLVk5KWlk5ZG1vbFBOa0Faajh6MjBMOXV6cGF0clRZVFI2QThxL3NSbitpbk83WlFWUTAwWE82cTZsWVlRenhudz09In0sIkNhcm9sIjp7IktleSI6Ikl0cnZTMDJuU2ZiY0EyZmwxTDFpNjF4cVBFREtSZHNyWWUzK1VDYmtUK2lwaGVpUVJQU3Vpa2J6ZVYya3NobjR5SkRla3U1Ym1UTnFXOEhTR3RVN0dUZ0NvSVdWOFdtRWY0dzZvdnpTaFBidStWckladlJ6M3dqaDJvWUhUL2d0UFZBUW5CYS83MUZlb0JOeHk1bC9oQmNVbUJreTQzajgzTWx0Mis4UVp4NlBFVURtcGFQUWVtVmg5OStDMjBuUXRrQVVGZU1jMkdlNHk3UmxIU3h0ZkFCdndsWHgxTnpDRDQwbnlKZkYxU2pWL2ZaaC9FMkFsNFRhdng2RE9Ka1lHb0oybXA3WEJ2WDBJRjJ0cDhUM1U1VnBuVGVrL1d1TnJMTDl6Ny9qcXpXaDg3bFo1S2hlV1hoR2tVMUJOSDRsZklqNDNwRGtTeTUwYUR2UzB6WWZIUT09In19LCJJViI6IjU4cjlNejhlMDZtSXRCRzluU1YvMFE9PSIsIkRhdGEiOiJRRTlaaGNHWE5YYXVVZE1rMDRiaVVHeTFTb1A1SDJuRi9qMkpqaWlWRktQZElkUnAvR2MrQVp2VUk5bjIyWk00cSt6RGlKejdxdks0YkthUHBYaFRtR1AwWGhlYUZVdWtlVk5TOVNUTW9UYk5jWS9adFZPejZoaXpVUEY3Z1NxMzg4UVBVc1QrQXhtbDNyRVVUV09obnc9PSIsIlNpZ25hdHVyZSI6IlZWaVJvYUN4cUtBdk54eU14RGhydFlvMENaQT0ifQ==\"}")
 	diskVault := []byte("{\"Version\":1,\"VaultId\":5298538957754540810,\"HmacKey\":\"Qugc5ZQ0vC7KQSgmDHTVgQ==\",\"Passwords\":{\"Alice\":{\"Type\":\"RSA\",\"PasswordSalt\":\"HrVbQ4JvEdORxWN6FrSy4w==\",\"HashedPassword\":\"nanadB0t/EmVuHyRUNtfyQ==\",\"KeySalt\":\"u0cwMmHikadpxm9wClrf3g==\",\"AESKey\":\"pOcxCYMk0l+kaEM5IHolfA==\",\"RSAKey\":{\"RSAExp\":\"yDBotK0XkaDk6rt35ciBnlyPGSXjp9ypdTH2j89CybXe2ReF6xLVZ10CCoz91UUFpbiQi2tVWFS8V7lxUehx7C6HI30Zr0iwJMXk8sgRKs2Ee3rAGCrM9vvQMO8ApKwe4kvB+PrFgnhIEgZI7zyPJPcdZnxbcVFyUC3uIivFS4Bv3jVBnrkAx71keQqrkKzu3jTquCIS3rTEm2hrgsZ3n1t/4BADvUpcMpII2Phv2Senonp1EMz9sRFsR4w9HVep8AgfUGuPTcQ/uv9R16xiHvlN80rOtWzVLpEruzGw/JTvlsshFBU5SY/zthGl9TwxWz1yZpVHYhIWhbxw34CXYczB6q19bdEPkJJldi/1coI=\",\"RSAExpIV\":\"RI9B8nzwW/CXiIU4lSYRWg==\",\"RSAPrimeP\":\"yB3TMdRhWLiZ/ayPlu/iLDHxWsuMi9pA8Ctps7WZFxVsxYEzy/s0Otzsbtgay8of72xVkO64MaudXXRjj26kVSQhS8WhPmv7xDO5ba3SsTffCA99aSr3MH+JmUoL+EDjYviUf5F1DSZniv+Ae+6x9AMbbRQqRvmdH/INW76rFbLX4VtsMpgVkAhADwCUSfNS\",\"RSAPrimePIV\":\"ZE8xe7zVqz4fTN1XWvD1Tg==\",\"RSAPrimeQ\":\"pq7rEAmXoiMWhuEpTy2pQiheLHuzcGeGm1IsgtP7TRIpHaumBAjasxhMY95ODspzehfHp8RPb3pz550g+EXpRP5bfmZkiPMGWKsFUWY7h51hm2Yg6t7yOSXxQvzseWDUjJqBXIG56su0ItD/7NT9YPnhOWAcLaV+L/D3dLdUOP3sgrfp2fcz5IWgcAHUKwLj\",\"RSAPrimeQIV\":\"po4GB9LNDJEFwVo7pd7M+w==\",\"RSAPublic\":{\"N\":23149224936745228096494487629641309516714939646787578848987096719230079441991920927625328021835418605829165905957281054739040782220661415211495551591590967025905842090248342119030961900558364831442589592519977574953153506098793781379522492850670706181134690851176026007414311463584686376540335844073069224992659463459793269384975134553539299820716318523937519020382533972574258510063896159690996712751336541794097684994088922002126390397554509324964165816682788604802958437629743951677011277308533675371215221012180522157452368867794857042597831942805118364469257052754518983480732149823871291876054393236400292711237,\"E\":65537}},\"Admin\":true},\"Bob\":{\"Type\":\"RSA\",\"PasswordSalt\":\"yqWZFNuuCRMw+snL83FcWQ==\",\"HashedPassword\":\"jYLSUIdvw8UVXhxVSS5uKQ==\",\"KeySalt\":\"ZJDOGSv9yUlJ5+83+FV6Nw==\",\"AESKey\":\"9bj4qQDJKglD9eIm7MNeag==\",\"RSAKey\":{\"RSAExp\":\"rnmHX1FgAN0KFm89Uj+O4L7/njDlQPwGHSYjGKB7qMyNPGF4jKn9ez1LI9e9jI8uE475KBhoXRmIuHdap6HtD+sH+nHugDzD3np6Dbq1MM+19PW41n9xblwx6tsNwvufCYgb2qtZd0bLXemeKBszJg2UXlTeSHkXGmjY/VAbZYbUFUNKIykiJWnQ+3HlAo7UHjjKSDI6HtiMnODwYucKH9uYdmroM3DqRUP+j+AhMctyeyOt68q6RuVyubzG0PM1/T9QqPgTIzFvg9dxk+LmPYmlv4b7Euea7KQHww4kTUlpNYondRisuA436G7EfWIJFeRShFuSVk0GvmrgN5vK+/FkdqMuikPaPV1dITFzaCU=\",\"RSAExpIV\":\"eoIov2XYwK19tpFkZyTL+Q==\",\"RSAPrimeP\":\"x9VqeHfHZBMksWNz3Bq90KyLYO0+y9tbfH17uAxQHIZbhn6RUHMXJFs4/H+TnL9s7D05HdxKNCD3ilISkhLZ/DQVD+VMvSFQ/2DL/OoKNg4UyxeGpKefJxCU9LOeXGTfN+UpGHN4Myal3PL2yi0yWCVZvX+zPks05Nqmzkmtx1Yz0IqeUaR+I1jw2y0xy+nc\",\"RSAPrimePIV\":\"h+J0h35kSaNFjBFyejmqSQ==\",\"RSAPrimeQ\":\"CUGaukdC8slcy1Qm6kBw8QYhVenJWFylPqJTvf03ATkkaxQJ8ZSK/RodXFiKCztRSx/HVw0LoGGx9RiavSxl1I+NPIiGEBXiYnLCwWjIbohEIviX0XrKEegECKZtEPxlkDGI8C5ScmUiUOoCUFODqPi1ymEPPIpqj6NZu0Q3lOXseZ7vHbCwiO7Nxznoed2V\",\"RSAPrimeQIV\":\"fglAccK/JKbbP6FKd3MoPA==\",\"RSAPublic\":{\"N\":28335031342838743289078885439639803673108967200362163631216970159249785951860249148476503896024171065194110189927394386737974335124568755441420594193064949823336810514078294805084876384362160530316962043860952904024334641317905429962254720146672817625880231384279651687169091903559644110839987019710966818515746956556387614880164417442090115347521394174077031531398826388780347541493782387177778507223791525305993050791342196579264299166530031123364885677134064847664024722422373550942639559346558112737229502294633354781474882714474174085566901518771722057743396746938093859383451665388899451851738694979184054459471,\"E\":65537}},\"Admin\":false},\"Carol\":{\"Type\":\"RSA\",\"PasswordSalt\":\"kPCA68PNIi3qODVfBHonMA==\",\"HashedPassword\":\"L05ueGkNhqRI7xo7OaG5fQ==\",\"KeySalt\":\"bUXHAjmdtpcYMNN/YzHvhA==\",\"AESKey\":\"34sh2HYt11JMd63CTC2g3Q==\",\"RSAKey\":{\"RSAExp\":\"blJ6FvmAC6ZegcR6ITdg8WDSMljcikrUp3dRGbRDgKIfK0sx7b9i/kDtp4uD7/3IuTpD/qq09k07PO10T5R9NI2OdaEUGsoKJ4wqyzP6XzC9l/KeQmU7cMTh5OHO5UcqXWBn+g1INWaWI6DNAPFKK+4jcTyy6gTQQZQKSYRvRmgN6GkjOhbsdH0eM29eZScShJy2cGemZwbx8g2x7+cebALJmnJxycq29uBZaNBq4gV2/oNXxUhAogJY8SVhgPzCgig2MAJBLK/PzzxJ2LgnBLosZkUXo4vLPKSELX0qXSkSOoC/qPXvcQGawsknqUkSaaDwB1T1MYHmcJS/wpiIRM89Qru0Oy8sy8NRApk3ef0=\",\"RSAExpIV\":\"pQnJ6tvdJkPmMkqFjwJg5g==\",\"RSAPrimeP\":\"xTwgxhDvEvMCn8W6Mqv4ogRnBXFTLbuLP8YC2exQ+RwKmUbNsjB1eBlHyYRtKwc7qoDLf/zqpMZk3yPPcQDP+szAS5mmhCgpd+ePee8vvwVR5DImDuCquMGrPNEgpg3LL1aBHMF66pfnYGob+P6GZYzJP3mhlewUlh86NDzP8YkoVlrNRZrarB1/ZmA+w2Y2\",\"RSAPrimePIV\":\"BYynxyFw7WxrpSKJ3ogwOw==\",\"RSAPrimeQ\":\"wrSXyN/gpDTvK/BMeH+04uhzGUFVbBrfo47L3i+E1QsQndJDy2yyyE1D26mFcvyiefObaD097M3ruR9Wz7WfjxmyawG8N2W/BgtHZz/Ds2ThN/T9t1XqskxnIV8l2eq9LL7SqjAyp8jUGMNVS4WODDtDngLIR6OeehfyHpgwVZRuqQMxIT3wA78SwDcWo41s\",\"RSAPrimeQIV\":\"nh42rsJHRpRyrT7DUHCSGQ==\",\"RSAPublic\":{\"N\":21157349824302424474586534982259249211803834319040688464355493234801787797103302507532796077498450217821871970018694577875997137564403612290101696297388762661598985028358214691463545987525906601624475015641369758738594698734277968689933610815708041386873182005594893971935327515126641632178583839753604241275307504709356922001828087700047657269629468786192584360390570302228520684623917906322926285597325969441240603594319235541820769758760147548185811818605055779607442920451051925838835969679126714958513824527149123555098280031335447316080110515987423541389176918537439220114191601986031091845506241054078769049741,\"E\":65537}},\"Admin\":false}}}")
 

--- a/cryptor/cryptor_test.go
+++ b/cryptor/cryptor_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/cloudflare/redoctober/keycache"
 	"github.com/cloudflare/redoctober/passvault"
@@ -107,7 +108,8 @@ func TestDuplicates(t *testing.T) {
 
 	// Delegate one key at a time and check that decryption fails.
 	for name, pr := range recs {
-		err = cache.AddKeyFromRecord(pr, name, "weakpassword", nil, nil, 2, "", "1h")
+		duration, _ := time.ParseDuration("1h")
+		err = cache.AddKeyFromRecord(pr, name, "weakpassword", "", &keycache.Usage{2, nil, nil, time.Now().Add(duration), true})
 		if err != nil {
 			t.Fatalf("%v", err)
 		}

--- a/cryptor/cryptor_test.go
+++ b/cryptor/cryptor_test.go
@@ -109,7 +109,15 @@ func TestDuplicates(t *testing.T) {
 	// Delegate one key at a time and check that decryption fails.
 	for name, pr := range recs {
 		duration, _ := time.ParseDuration("1h")
-		err = cache.AddKeyFromRecord(pr, name, "weakpassword", "", &keycache.Usage{2, nil, nil, time.Now().Add(duration), true})
+		err = cache.AddKeyFromRecord(
+			pr, name, "weakpassword", "", &keycache.Usage{
+				Uses:    2,
+				Labels:  nil,
+				Users:   nil,
+				Expiry:  time.Now().Add(duration),
+				AnyUser: true,
+			},
+		)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}

--- a/keycache/keycache.go
+++ b/keycache/keycache.go
@@ -31,10 +31,11 @@ type DelegateIndex struct {
 
 // Usage holds the permissions of a delegated permission
 type Usage struct {
-	Uses   int       // Number of uses delegated
-	Labels []string  // File labels allowed to decrypt
-	Users  []string  // Set of users allows to decrypt
-	Expiry time.Time // Expiration of usage
+	Uses    int       // Number of uses delegated
+	Labels  []string  // File labels allowed to decrypt
+	Users   []string  // Set of users allows to decrypt
+	Expiry  time.Time // Expiration of usage
+	AnyUser bool      // True if any user is permitted, false otherwise
 }
 
 // ActiveUser holds the information about an actively delegated key.
@@ -72,13 +73,17 @@ func (usage Usage) matchesLabel(labels []string) bool {
 }
 
 // matches returns true if this usage applies the user and label
-// an empty array of Users indicates that all users are valid
+// also returns true if the usage is marked with AnyUser set to true
+// DEPRECATED: an empty array of Users indicates that all users are valid
 func (usage Usage) matches(user string, labels []string) bool {
 	if !usage.matchesLabel(labels) {
 		return false
 	}
-	// if usage lists no users, always match
+	// DEPRECATED: if usage lists no users, always match
 	if len(usage.Users) == 0 {
+		return true
+	}
+	if usage.AnyUser {
 		return true
 	}
 	for _, validUser := range usage.Users {
@@ -173,20 +178,11 @@ func (cache *Cache) Refresh() {
 }
 
 // AddKeyFromRecord decrypts a key for a given record and adds it to the cache.
-func (cache *Cache) AddKeyFromRecord(record passvault.PasswordRecord, name, password string, users, labels []string, uses int, slot, durationString string) (err error) {
+func (cache *Cache) AddKeyFromRecord(record passvault.PasswordRecord, name, password, slot string, usage *Usage) (err error) {
 	var current ActiveUser
 
 	cache.Refresh()
-
-	// compute exipiration
-	duration, err := time.ParseDuration(durationString)
-	if err != nil {
-		return
-	}
-	current.Usage.Uses = uses
-	current.Usage.Expiry = time.Now().Add(duration)
-	current.Usage.Users = users
-	current.Usage.Labels = labels
+	current.Usage = *usage
 
 	// get decryption keys
 	switch record.Type {

--- a/keycache/keycache.go
+++ b/keycache/keycache.go
@@ -74,14 +74,9 @@ func (usage Usage) matchesLabel(labels []string) bool {
 
 // matches returns true if this usage applies the user and label
 // also returns true if the usage is marked with AnyUser set to true
-// DEPRECATED: an empty array of Users indicates that all users are valid
 func (usage Usage) matches(user string, labels []string) bool {
 	if !usage.matchesLabel(labels) {
 		return false
-	}
-	// DEPRECATED: if usage lists no users, always match
-	if len(usage.Users) == 0 {
-		return true
 	}
 	if usage.AnyUser {
 		return true

--- a/keycache/keycache.go
+++ b/keycache/keycache.go
@@ -176,6 +176,10 @@ func (cache *Cache) Refresh() {
 func (cache *Cache) AddKeyFromRecord(record passvault.PasswordRecord, name, password, slot string, usage *Usage) (err error) {
 	var current ActiveUser
 
+	// Ensure a list of Users is given or the AnyUser flag is set
+	if (usage.Users == nil || len(usage.Users) == 0) && usage.AnyUser == false {
+		return errors.New("Must provide a list of Users or set the AnyUser flag to true")
+	}
 	cache.Refresh()
 	current.Usage = *usage
 

--- a/keycache/keycache_test.go
+++ b/keycache/keycache_test.go
@@ -56,7 +56,7 @@ func TestUsesFlush(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	key2, err := cache.DecryptKey(encKey, "user", "anybody", []string{}, pubEncryptedKey)
+	key2, err := cache.DecryptKey(encKey, "user", "alice", []string{}, pubEncryptedKey)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -66,7 +66,7 @@ func TestUsesFlush(t *testing.T) {
 	}
 
 	// Second decryption allowed.
-	_, err = cache.DecryptKey(encKey, "user", "anybody else", []string{}, pubEncryptedKey)
+	_, err = cache.DecryptKey(encKey, "user", "alice", []string{}, pubEncryptedKey)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -110,7 +110,7 @@ func TestTimeFlush(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	_, err = cache.DecryptKey(dummy, "user", "anybody", []string{}, pubEncryptedKey)
+	_, err = cache.DecryptKey(dummy, "user", "alice", []string{}, pubEncryptedKey)
 	if err == nil {
 		t.Fatalf("Error in pruning expired key")
 	}
@@ -148,7 +148,7 @@ func TestGoodLabel(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	_, err = cache.DecryptKey(dummy, "user", "anybody", []string{"red"}, pubEncryptedKey)
+	_, err = cache.DecryptKey(dummy, "user", "alice", []string{"red"}, pubEncryptedKey)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
This change resolves https://github.com/cloudflare/redoctober/issues/119 by adding an explicit option (`"AnyUser"`) for a delegator to allow _any user_ to decrypt requested data. This improves on the current design, where a delegator must specify an empty list of users for the same effect.
#### Adding the AnyUser Option

Commit 4093134d91a3c9764757ae6b17b634c65209fd0a adds the initial enhancement by extending the API for `Cache.AddKeyFromRecord()`. At this point, the function signature for this function is getting pretty heavy, but as it's only used once in `core/core.go`, this is probably OK (The test dependencies may be another matter). We document that delegating to an empty list of users is deprecated functionality, but still support it. Also adds CLI support for the same flag.

Edit: The function signature for `Cache.AddKeyFromRecord()` now accepts a `Usage` object to simplify it's API.
#### Enforcing the AnyUser Option

Commit 5549d4c6f6b1ca9e65204db0e95dee0e6b018308 adds enforcement (thereby breaking backwards-compatibility) of the flag by returning an error in `core/core.go` if we don't receive a list of `Users` or if the `AnyUser` flag is not set. This break the old, undesired behavior, and have to update quite a few test vectors to reflect the new API.

Thoughts on rolling these changes out incrementally to allow applications time to upgrade to the modified `/delegate` API?
