### PR TITLE
Upgrade to Go 1.5 in Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: go
-go: 1.4
+go: 1.5
 script:
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/modocache/gover
   - go get github.com/cloudflare/redoctober
   - go test github.com/cloudflare/redoctober...


### PR DESCRIPTION
Per [Go 1.4 x/tools deprecation notice](https://groups.google.com/forum/#!topic/golang-announce/qu_rAphYdxY), certain packages in `x/tools` for Go 1.4 have been moved from their prior homes into the standard library starting with Go 1.5. Upgrading `travis.yml` to use Go 1.5 should fix this issue, since the packages at the old locations have now been removed.

This issue currently causes test failure in https://github.com/cloudflare/redoctober/pull/134
![screen shot 2016-04-13 at 10 21 06 am](https://cloud.githubusercontent.com/assets/9010671/14502778/e3cbd8d2-0161-11e6-8d2a-94977c3105e5.png)
