### PR TITLE
redoctober: disable HTTP/2.

### DIFF
--- a/redoctober.go
+++ b/redoctober.go
@@ -170,9 +170,10 @@ func NewServer(staticPath, addr, caPath string, certPaths, keyPaths []string, us
 	mux.HandleFunc("/", idxHandler.handle)
 
 	srv := http.Server{
-		Addr:      addr,
-		Handler:   mux,
-		TLSConfig: config,
+		Addr:         addr,
+		Handler:      mux,
+		TLSConfig:    config,
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 
 	// The core package is not safe to be shared across goroutines so


### PR DESCRIPTION
There is an issue connecting to the HTTPS UI with HTTP/2 support.
Debugging is ongoing, but the immediate fix is to disable HTTP/2.