### PR TITLE
Switch to string fields for key and certificate paths.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ type Server struct {
 
 	// KeyPaths and CertPaths contains a list of paths to TLS key
 	// pairs that should be used to secure connections to the
-	// server.
-	KeyPaths  []string `json:"private_keys"`
-	CertPaths []string `json:"certificates"`
+	// server. The paths should be comma-separated.
+	KeyPaths  string `json:"private_keys"`
+	CertPaths string `json:"certificates"`
 
 	// Systemd indicates whether systemd socket activation should
 	// be used instead of a normal port listener.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,8 +109,8 @@ func TestMergeEmpty(t *testing.T) {
 		Server: &Server{
 			Addr:      "localhost:8080",
 			CAPath:    "",
-			KeyPaths:  []string{"testdata/server.key"},
-			CertPaths: []string{"testdata/server.pem"},
+			KeyPaths:  "testdata/server.key",
+			CertPaths: "testdata/server.pem",
 			Systemd:   true,
 		},
 		UI: &UI{
@@ -147,8 +147,8 @@ func TestMergeOverride(t *testing.T) {
 	config.Server = &Server{
 		Addr:      "localhost:443",
 		CAPath:    "",
-		KeyPaths:  []string{"testdata/server.key"},
-		CertPaths: []string{"testdata/server.pem"},
+		KeyPaths:  "testdata/server.key",
+		CertPaths: "testdata/server.pem",
 	}
 
 	merge := New()
@@ -160,8 +160,8 @@ func TestMergeOverride(t *testing.T) {
 	expected.Server = &Server{
 		Addr:      "localhost:8000",
 		CAPath:    "",
-		KeyPaths:  []string{"testdata/server.key"},
-		CertPaths: []string{"testdata/server.pem"},
+		KeyPaths:  "testdata/server.key",
+		CertPaths: "testdata/server.pem",
 	}
 
 	if config.equal(merge) {
@@ -185,8 +185,8 @@ func TestLoadFile(t *testing.T) {
 	expected := New()
 	expected.Server = &Server{
 		Addr:      "localhost:8080",
-		KeyPaths:  []string{"testdata/server.key"},
-		CertPaths: []string{"testdata/server.pem"},
+		KeyPaths:  "testdata/server.key",
+		CertPaths: "testdata/server.pem",
 	}
 
 	_, err := Load("testdata/enoent.json")
@@ -218,20 +218,20 @@ func TestValid(t *testing.T) {
 	}
 
 	// Certs and no keys is an invalid config.
-	config.Server.CertPaths = []string{"testdata/server.pem"}
+	config.Server.CertPaths = "testdata/server.pem"
 	if config.Valid() {
 		t.Fatal("config shouldn't be valid")
 	}
 
 	// Keys and no certs is an invalid config.
-	config.Server.CertPaths = nil
-	config.Server.KeyPaths = []string{"testdata/server.key"}
+	config.Server.CertPaths = ""
+	config.Server.KeyPaths = "testdata/server.key"
 	if config.Valid() {
 		t.Fatal("config shouldn't be valid")
 	}
 
 	// Key pairs but no address information is an invalid config.
-	config.Server.CertPaths = []string{"testdata/server.pem"}
+	config.Server.CertPaths = "testdata/server.pem"
 	if config.Valid() {
 		t.Fatal("config shouldn't be valid")
 	}

--- a/config/testdata/bad_config.json
+++ b/config/testdata/bad_config.json
@@ -1,8 +1,8 @@
 {
     "server": {
 	"address":      "localhost:8080",
-	"private_keys": ["testdata/server.key"],
-	"certificates": ["testdata/server.pem"],
+	"private_keys": "testdata/server.key",
+	"certificates": "testdata/server.pem",
     },
 }
     

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -1,12 +1,8 @@
 {
     "server": {
         "address": "localhost:8080",
-        "private_keys": [
-            "testdata/server.key"
-        ],
-        "certificates": [
-            "testdata/server.pem"
-        ]
+        "private_keys": "testdata/server.key",
+        "certificates": "testdata/server.pem"
     }
 }
     

--- a/redoctober.go
+++ b/redoctober.go
@@ -243,8 +243,6 @@ func init() {
 	cli = config.New()
 	cfg = config.New()
 
-	var certsPath, keysPath string
-
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "main usage dump\n")
 		fmt.Fprint(os.Stderr, usage)
@@ -255,11 +253,11 @@ func init() {
 	flag.StringVar(&confFile, "f", "", "path to config file")
 	flag.StringVar(&cli.Server.Addr, "addr", "localhost:8080", "Server and port separated by :")
 	flag.StringVar(&cli.Server.CAPath, "ca", "", "Path of TLS CA for client authentication (optional)")
-	flag.StringVar(&certsPath, "certs", "", "Path(s) of TLS certificate in PEM format, comma-separated")
+	flag.StringVar(&cli.Server.CertPaths, "certs", "", "Path(s) of TLS certificate in PEM format, comma-separated")
 	flag.StringVar(&cli.HipChat.Host, "hchost", "", "Hipchat Url Base (ex: hipchat.com)")
 	flag.StringVar(&cli.HipChat.APIKey, "hckey", "", "Hipchat API Key")
 	flag.StringVar(&cli.HipChat.Room, "hcroom", "", "Hipchat Room Id")
-	flag.StringVar(&keysPath, "keys", "", "Path(s) of TLS private key in PEM format, comma-separated, must me in the same order as the certs")
+	flag.StringVar(&cli.Server.KeyPaths, "keys", "", "Path(s) of TLS private key in PEM format, comma-separated, must me in the same order as the certs")
 	flag.StringVar(&cli.Metrics.Host, "metrics-host", "localhost", "The `host` the metrics endpoint should listen on.")
 	flag.StringVar(&cli.Metrics.Port, "metrics-port", "8081", "The `port` the metrics endpoint should listen on.")
 	flag.StringVar(&cli.UI.Root, "rohost", "", "RedOctober Url Base (ex: localhost:8080)")
@@ -268,9 +266,6 @@ func init() {
 	flag.StringVar(&vaultPath, "vaultpath", "diskrecord.json", "Path to the the disk vault")
 
 	flag.Parse()
-
-	cli.Server.CertPaths = strings.Split(certsPath, ",")
-	cli.Server.KeyPaths = strings.Split(keysPath, ",")
 }
 
 //go:generate go run generate.go
@@ -296,8 +291,10 @@ func main() {
 	}
 
 	initPrometheus()
+	cpaths := strings.Split(cfg.Server.CertPaths, ",")
+	kpaths := strings.Split(cfg.Server.KeyPaths, ",")
 	s, l, err := NewServer(cfg.UI.Static, cfg.Server.Addr, cfg.Server.CAPath,
-		cfg.Server.CertPaths, cfg.Server.KeyPaths, cfg.Server.Systemd)
+		cpaths, kpaths, cfg.Server.Systemd)
 	if err != nil {
 		log.Fatalf("Error starting redoctober server: %s\n", err)
 	}


### PR DESCRIPTION
This simplifies our deployment process, allowing us to use existing
configuration management tools designed for templating command-line
parameters to template the config files in a straightforward manner.