### PR TITLE
make docker: build a docker image for redoctober

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.gitignore
+.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
-FROM golang:1.6.3
+FROM golang:1.7.0
+
+RUN groupadd -r redoctober --gid=999 && useradd -r -g redoctober --uid=999 redoctober
+
+# grab openssl for generating certs and runit for chpst
+RUN apt-get update && \
+    apt-get install -y openssl runit
 
 COPY . /go/src/github.com/cloudflare/redoctober
 RUN go get github.com/cloudflare/redoctober/...
 
-EXPOSE 8080
-ENTRYPOINT ["redoctober"]
+EXPOSE 8080 8081
+ENV RO_DATA=/var/lib/redoctober/data \
+    RO_CERTPASSWD=password \
+    RO_COMMONNAME=localhost
+
+ENTRYPOINT ["/go/src/github.com/cloudflare/redoctober/scripts/docker-entrypoint.sh"]
+CMD ["redoctober", \
+    "-addr=:8080", \
+    "-vaultpath=/var/lib/redoctober/data/diskrecord.json", \
+    "-certs=/var/lib/redoctober/data/server.crt", \
+    "-keys=/var/lib/redoctober/data/server.pem"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.6.3
+
+COPY . /go/src/github.com/cloudflare/redoctober
+RUN go get github.com/cloudflare/redoctober/...
+
+EXPOSE 8080
+ENTRYPOINT ["redoctober"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.0
+FROM golang:1.7.1
 
 RUN groupadd -r redoctober --gid=999 && useradd -r -g redoctober --uid=999 redoctober
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ RUN apt-get update && \
     apt-get install -y openssl runit
 
 COPY . /go/src/github.com/cloudflare/redoctober
-RUN go get github.com/cloudflare/redoctober/...
+RUN go install github.com/cloudflare/redoctober
 
 EXPOSE 8080 8081
-ENV RO_DATA=/var/lib/redoctober/data \
+ENV RO_CERTS=/var/lib/redoctober/data/server.crt \
+    RO_KEYS=/var/lib/redoctober/data/server.pem \
+    RO_DATA=/var/lib/redoctober/data \
     RO_CERTPASSWD=password \
     RO_COMMONNAME=localhost
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: docker
+docker:
+	@docker build -t cloudflare/redoctober:$(shell git rev-parse --short HEAD) .
+	@docker tag cloudflare/redoctober:$(shell git rev-parse --short HEAD) cloudflare/redoctober:latest

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -3,28 +3,28 @@ set -e
 
 # if we are not bind mounting in certs or the user has not already generated certs
 # create self-signed certs
-if [ ! -d $RO_DATA ]; then
+if [ ! -f $RO_CERTS ] || [ ! -f $RO_KEYS ]; then
 	mkdir -p $RO_DATA
 	chmod 700 $RO_DATA
 	chown -R redoctober:redoctober $RO_DATA
 
 	# Generate private key with password "$RO_CERTPASSWD"
-	openssl genrsa -aes128 -passout pass:$RO_CERTPASSWD -out $RO_DATA/server.pem 2048
+	openssl genrsa -aes128 -passout pass:$RO_CERTPASSWD -out $RO_KEYS 2048
 	# Remove password from private key
-	openssl rsa -passin pass:$RO_CERTPASSWD -in $RO_DATA/server.pem -out $RO_DATA/server.pem
+	openssl rsa -passin pass:$RO_CERTPASSWD -in $RO_KEYS -out $RO_KEYS
 	# Generate CSR (make sure the common name CN field matches your server
-	# address. It's set to "localhost" here.)
-	openssl req -new -key $RO_DATA/server.pem -out $RO_DATA/server.csr -subj "/C=US/ST=California/L=Everywhere/CN=${RO_COMMONNAME}"
+	# address. It's set to "RO_COMMONNAME" environment variable here.)
+	openssl req -new -key $RO_KEYS -out $RO_DATA/server.csr -subj "/C=US/ST=California/L=Everywhere/CN=${RO_COMMONNAME}"
 	# Sign the CSR and create certificate
-	openssl x509 -req -days 365 -in $RO_DATA/server.csr -signkey $RO_DATA/server.pem -out $RO_DATA/server.crt
+	openssl x509 -req -days 365 -in $RO_DATA/server.csr -signkey $RO_KEYS -out $RO_CERTS
 
 	# Clean up
 	rm $RO_DATA/server.csr
-	chmod 600 $RO_DATA/*
-	chown -R redoctober $RO_DATA
+	chmod 600 $RO_CERTS $RO_KEYS
+	chown -R redoctober $RO_CERTS $RO_KEYS
 
 	echo
-	echo "Generated default certificates for RedOctobeer at $RO_DATA"
+	echo "Generated default certificates for RedOctobeer at $RO_CERTS and $RO_KEYS"
 	echo
 fi
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+# if we are not bind mounting in certs or the user has not already generated certs
+# create self-signed certs
+if [ ! -d $RO_DATA ]; then
+	mkdir -p $RO_DATA
+	chmod 700 $RO_DATA
+	chown -R redoctober:redoctober $RO_DATA
+
+	# Generate private key with password "$RO_CERTPASSWD"
+	openssl genrsa -aes128 -passout pass:$RO_CERTPASSWD -out $RO_DATA/server.pem 2048
+	# Remove password from private key
+	openssl rsa -passin pass:$RO_CERTPASSWD -in $RO_DATA/server.pem -out $RO_DATA/server.pem
+	# Generate CSR (make sure the common name CN field matches your server
+	# address. It's set to "localhost" here.)
+	openssl req -new -key $RO_DATA/server.pem -out $RO_DATA/server.csr -subj "/C=US/ST=California/L=Everywhere/CN=${RO_COMMONNAME}"
+	# Sign the CSR and create certificate
+	openssl x509 -req -days 365 -in $RO_DATA/server.csr -signkey $RO_DATA/server.pem -out $RO_DATA/server.crt
+
+	# Clean up
+	rm $RO_DATA/server.csr
+	chmod 600 $RO_DATA/*
+	chown -R redoctober $RO_DATA
+
+	echo
+	echo "Generated default certificates for RedOctobeer at $RO_DATA"
+	echo
+fi
+
+if [ "$1" = 'redoctober' ]; then
+	exec chpst -u redoctober "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Running `make docker` will build a simple image that contains redoctober binary. This makes integrating with other projects that uses RedOctober API a bit easier.

Sample test build:

```
$ make docker
Sending build context to Docker daemon 1.068 MB
Step 1 : FROM golang:1.6.3
 ---> bc1c55b17233
Step 2 : COPY . /go/src/github.com/cloudflare/redoctober
 ---> 53a4aadde807
Removing intermediate container 4a9771cb6b1d
Step 3 : RUN go get github.com/cloudflare/redoctober/...
 ---> Running in 47ed95dec301
 ---> 2bbb0fa4c761
Removing intermediate container 47ed95dec301
Step 4 : ENTRYPOINT redoctober
 ---> Running in abb4073f4c3b
 ---> 9e6833026bec
Removing intermediate container abb4073f4c3b
Successfully built 9e6833026bec
```

We probably should also vendor for reproducible builds but that should be another PR.