### PR TITLE
kyle/keycache interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,8 +77,18 @@ type Delegations struct {
 	Persist bool `json:"persist"`
 
 	// Policy contains the MSP predicate for delegation
-	// persistence.
-	Policy string `json:"policy"`
+	// persistence, and users contains the users allowed
+	// to delegate.
+	Policy string   `json:"policy"`
+	Users  []string `json:"users"`
+
+	// Mechanism specifies the persistence mechanism to use.
+	Mechanism string `json:"mechanism"`
+
+	// Location contains location information for the persistence
+	// mechanism, such as a file path or database connection
+	// string.
+	Location string `json:"location"`
 }
 
 // Config contains all the configuration options for a redoctober

--- a/persist/file.go
+++ b/persist/file.go
@@ -1,0 +1,122 @@
+package persist
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/cloudflare/redoctober/config"
+	"github.com/cloudflare/redoctober/keycache"
+	"github.com/cloudflare/redoctober/passvault"
+)
+
+// File implements a file-backed persistence store.
+type File struct {
+	config *config.Delegations
+	cache  *keycache.Cache
+	state  string
+	blob   []byte
+}
+
+// Valid ensures the configuration is valid for a file store. Note
+// that it won't validate the policy, it will just ensure that one
+// is present.
+func (f *File) Valid() bool {
+	if f.config.Persist == false {
+		return false
+	}
+
+	if f.config.Policy == "" {
+		return false
+	}
+
+	if len(f.config.Users) == 0 {
+		return false
+	}
+
+	if f.config.Mechanism != FileMechanism {
+		return false
+	}
+
+	if f.config.Location == "" {
+		return false
+	}
+
+	return true
+}
+
+// newFile returns a new file-backed persistence store.
+func newFile(config *config.Delegations) (Store, error) {
+	cache := keycache.NewCache()
+	file := &File{
+		config: config,
+		cache:  &cache,
+		state:  Inactive,
+	}
+
+	if !file.Valid() {
+		return nil, ErrInvalidConfig
+	}
+
+	err := file.Load()
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (f *File) Blob() []byte {
+	return f.blob
+}
+
+func (f *File) Policy() string {
+	return f.config.Policy
+}
+
+func (f *File) Users() []string {
+	return f.config.Users
+}
+
+func (f *File) Store(blob []byte) error {
+	if f.state == Active {
+		f.blob = blob
+		return ioutil.WriteFile(f.config.Location, blob, 0644)
+	}
+	return nil
+}
+
+func (f *File) Load() error {
+	in, err := ioutil.ReadFile(f.config.Location)
+	if err != nil {
+		// If the file doesn't exist, it can be persisted
+		// immediately.
+		if os.IsNotExist(err) {
+			f.state = Active
+			return nil
+		}
+
+		return err
+	}
+
+	f.state = Inactive
+	f.blob = in
+	return nil
+}
+
+func (f *File) Persist() {
+	f.state = Active
+}
+
+func (f *File) Cache() *keycache.Cache {
+	return f.cache
+}
+
+func (f *File) Delegate(record passvault.PasswordRecord, name, password string, users, labels []string, uses int, slot, durationString string) error {
+	return f.cache.AddKeyFromRecord(record, name, password, users, labels, uses, slot, durationString)
+}
+
+func (f *File) Status() *Status {
+	return &Status{
+		State:   f.state,
+		Summary: f.cache.GetSummary(),
+	}
+}

--- a/persist/file_test.go
+++ b/persist/file_test.go
@@ -1,0 +1,137 @@
+package persist
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/cloudflare/redoctober/config"
+)
+
+func TestFileConfig(t *testing.T) {
+	cfg := &config.Delegations{
+		Persist: false,
+	}
+	f := &File{config: cfg}
+
+	if f.Valid() {
+		t.Fatal("persist: File config should persist")
+	}
+
+	cfg.Persist = true
+	if f.Valid() {
+		t.Fatal("persist: File config should require policy")
+	}
+
+	cfg.Policy = "some policy"
+	if f.Valid() {
+		t.Fatal("persist: File config should require mechanism")
+	}
+
+	cfg.Users = []string{"alice", "bob"}
+
+	cfg.Mechanism = "db"
+	if f.Valid() {
+		t.Fatalf("persist: File config should require the '%s' mechanism", FileMechanism)
+	}
+
+	cfg.Mechanism = FileMechanism
+	if f.Valid() {
+		t.Fatal("persist: File config should require a location")
+	}
+
+	cfg.Location = "testdata/store.bin"
+	if !f.Valid() {
+		t.Fatal("persist: valid File config marked as invalid")
+	}
+
+	cfg.Location = ""
+	_, err := New(cfg)
+	if err != ErrInvalidConfig {
+		t.Fatalf("persist: expected err='%s', have err='%s'",
+			ErrInvalidConfig, err)
+	}
+}
+
+func tempName() (string, error) {
+	tmpf, err := ioutil.TempFile("", "transport_cachedkp_")
+	if err != nil {
+		return "", err
+	}
+
+	name := tmpf.Name()
+	tmpf.Close()
+	return name, nil
+}
+
+func TestFileSanity(t *testing.T) {
+	sf, err := tempName()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(sf)
+
+	const expected = "testdata"
+	err = ioutil.WriteFile(sf, []byte(expected), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Delegations{
+		Persist:   true,
+		Mechanism: FileMechanism,
+		Policy:    "alice & bob",
+		Users:     []string{"alice", "bob"},
+		Location:  sf,
+	}
+
+	f, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f.Blob()) != expected {
+		t.Fatalf("persist: expected blob data '%s' but have '%s'", expected, f.Blob())
+	}
+
+	if f.Policy() != cfg.Policy {
+		t.Fatalf("persist: policy mismatch - should have '%s' but have '%s'",
+			cfg.Policy, f.Policy())
+	}
+
+	if len(f.Users()) != 2 {
+		t.Fatalf("persist: expected 2 users, have %d", len(f.Users()))
+	}
+
+	const expected2 = "test data"
+	if err = f.Store([]byte(expected2)); err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f.Blob()) == expected2 {
+		t.Fatal("persist: should not have begun persisting yet")
+	}
+
+	f.Persist()
+	if err = f.Store([]byte(expected2)); err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f.Blob()) != expected2 {
+		t.Fatalf("persist: expected blob data '%s' but have '%s'", expected2, f.Blob())
+	}
+
+	err = ioutil.WriteFile(sf, []byte(expected), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = f.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f.Blob()) != expected {
+		t.Fatalf("persist: expected blob data '%s' but have '%s'", expected2, f.Blob())
+	}
+
+}

--- a/persist/null.go
+++ b/persist/null.go
@@ -1,0 +1,59 @@
+package persist
+
+import (
+	"errors"
+
+	"github.com/cloudflare/redoctober/config"
+	"github.com/cloudflare/redoctober/keycache"
+	"github.com/cloudflare/redoctober/passvault"
+)
+
+// Null is a non-persisting store. It is used when persistence is not
+// activated.
+type Null struct {
+	config *config.Delegations
+}
+
+func newNull(config *config.Delegations) (Store, error) {
+	return &Null{config: config}, nil
+}
+
+func (n *Null) Blob() []byte {
+	return nil
+}
+
+func (n *Null) Policy() string {
+	return n.config.Policy
+}
+
+func (n *Null) Users() []string {
+	return n.config.Users
+}
+
+func (n *Null) Store(bs []byte) error {
+	return nil
+}
+
+func (n *Null) Load() error {
+	return nil
+}
+
+func (n *Null) Persist() {
+	return
+}
+
+func (n *Null) Status() *Status {
+	return &Status{
+		State:   Disabled,
+		Summary: nil,
+	}
+}
+
+func (n *Null) Delegate(record passvault.PasswordRecord, name, password string, users, labels []string, uses int, slot, durationString string) error {
+	return errors.New("persist: null store does not support delegations")
+}
+
+func (n *Null) Cache() *keycache.Cache {
+	cache := keycache.NewCache()
+	return &cache
+}

--- a/persist/null_test.go
+++ b/persist/null_test.go
@@ -1,0 +1,60 @@
+package persist
+
+import (
+	"testing"
+
+	"github.com/cloudflare/redoctober/config"
+	"github.com/cloudflare/redoctober/passvault"
+)
+
+func TestNewNull(t *testing.T) {
+	cfg := &config.Delegations{
+		Persist:   false,
+		Mechanism: FileMechanism,
+		Location:  "testdata/store.bin",
+		Policy:    "policy",
+	}
+
+	store, err := New(cfg)
+	if err != nil {
+		t.Fatalf("persist: failed to create a new store: %s", err)
+	}
+
+	if _, ok := store.(*Null); !ok {
+		t.Fatalf("persist: expected a Null store, but have %T", store)
+	}
+
+	if store.Blob() != nil {
+		t.Fatalf("persist: Null store should return an empty blob")
+	}
+
+	if store.Policy() != cfg.Policy {
+		t.Fatalf("persist: expected a consistent policy")
+	}
+
+	if err := store.Store([]byte("test data")); err != nil {
+		t.Fatalf("persist: Null.Store failed with %s", err)
+	}
+
+	if err := store.Load(); err != nil {
+		t.Fatalf("persist: Null.Load failed with %s", err)
+	}
+
+	status := store.Status()
+	if status.State != Disabled {
+		t.Fatalf("persist: Null store should never persist")
+	}
+
+	if len(status.Summary) != 0 {
+		t.Fatal("persist: Null summary should have zero entries")
+	}
+
+	err = store.Delegate(passvault.PasswordRecord{}, "name", "password", []string{}, []string{}, 1, "", "1h")
+	if err == nil {
+		t.Fatal("persist: expected delegation to fail")
+	}
+
+	if cache := store.Cache(); len(cache.UserKeys) != 0 {
+		t.Fatal("persist: Null Cache should return an empty cache")
+	}
+}

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -1,0 +1,81 @@
+// Package persist implements delegation persistence. It is primarily
+// concerned with configuration and serialisation; encryption and
+// decryption is done by the cryptor package.
+package persist
+
+import (
+	"errors"
+
+	"github.com/cloudflare/redoctober/config"
+	"github.com/cloudflare/redoctober/keycache"
+	"github.com/cloudflare/redoctober/passvault"
+)
+
+var defaultStore Store = &File{}
+
+const (
+	// NeverPersist indicates that the persistence store will
+	// never persist active delegations.
+	Disabled = "disabled"
+
+	// Inactive indicates that the persistence store requires
+	// more delegations to unlock, and isn't currently persisting
+	// the store.
+	Inactive = "inactive"
+
+	// Active indicates that the persistence store is
+	// actively persisting delegations.
+	Active = "active"
+)
+
+// Status contains information on the current status of a persistence
+// store.
+type Status struct {
+	State   string `json:"state"`
+	Summary map[string]keycache.ActiveUser
+}
+
+// Store is a persistence store interface that handles delegations,
+// serialising the persistence store, and writing the store to disk.
+type Store interface {
+	Blob() []byte
+	Policy() string
+	Users() []string
+	Store([]byte) error
+	Load() error
+	Status() *Status
+	// Persist tells the Store to start actively persisting.
+	Persist()
+	Delegate(record passvault.PasswordRecord, name, password string, users, labels []string, uses int, slot, durationString string) error
+	// This is not the main keycache. This is the keycache for
+	// users that can decrypt the store.
+	Cache() *keycache.Cache
+}
+
+const FileMechanism = "file"
+
+type mechanism func(*config.Delegations) (Store, error)
+
+var stores = map[string]mechanism{
+	"":            newNull,
+	FileMechanism: newFile,
+}
+
+func New(config *config.Delegations) (Store, error) {
+	if config == nil {
+		return nil, errors.New("persist: nil configuration")
+	}
+
+	if !config.Persist {
+		return newNull(config)
+	}
+
+	constructor, ok := stores[config.Mechanism]
+	if !ok {
+		return nil, errors.New("persist: invalid persistence mechanism")
+	}
+
+	return constructor(config)
+}
+
+var ErrInvalidConfig = errors.New("persist: invalid configuration")

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -1,0 +1,26 @@
+package persist
+
+import (
+	"testing"
+
+	"github.com/cloudflare/redoctober/config"
+)
+
+func TestNew(t *testing.T) {
+	cfg := &config.Delegations{
+		Persist:   true,
+		Policy:    "policy",
+		Users:     []string{"alice"},
+		Mechanism: FileMechanism,
+		Location:  "testdata/store.bin",
+	}
+
+	store, err := New(cfg)
+	if err != nil {
+		t.Fatalf("persist: failed to create a new store: %s", err)
+	}
+
+	if _, ok := store.(*File); !ok {
+		t.Fatalf("persist: New should return a *File, but returned a %T", store)
+	}
+}


### PR DESCRIPTION
Implementation of a file-backed persistence store.

This is a rather large change. It consists of the following changes:

+ Direct access to the keycache has been removed from the core package. This forces all interaction with the cache to go through the Cryptor, which is required for persistence. The Cryptor needs to know when the cache has changed, and the only way to do this effectively is to make the Cryptor responsible for managing the keycache.

+ A new persist package has been added. This provides a Store interface, for which two implementations are provided. The first is a null persister: this is used when no persistence is configured. The second is a file-backed persistence store.

+ The Cryptor now persists the cache every time it changes.

Additionally, a number of missing returns in a function in the core package have been added.
