### PR TITLE
kyle/keycache_feedback

### DIFF
--- a/cryptor/cryptor_test.go
+++ b/cryptor/cryptor_test.go
@@ -293,6 +293,11 @@ func TestRestore(t *testing.T) {
 			persist.Inactive, status.State)
 	}
 
+	err = c.Restore("Carl", "weakpassword", 0, "", "0h")
+	if err != ErrRestoreDelegations {
+		t.Fatal(err)
+	}
+
 	err = c.Restore("Bob", "weakpassword", 2, "", "1h")
 	if err != nil {
 		t.Fatal(err)

--- a/msp/msp.go
+++ b/msp/msp.go
@@ -211,6 +211,10 @@ func (m MSP) DistributeShares(sec []byte, db UserDatabase) (map[string][][]byte,
 	return out, nil
 }
 
+// ErrNotEnoughShares is returned if there aren't enough shares to
+// decrypt the secret.
+var ErrNotEnoughShares = errors.New("Not enough shares to recover.")
+
 // RecoverSecret takes a user database storing secret shares as input and returns the original secret.
 func (m MSP) RecoverSecret(db UserDatabase) ([]byte, error) {
 	cache := make(map[string][][]byte, 0) // Caches un-used shares for a user.
@@ -225,7 +229,7 @@ func (m MSP) recoverSecret(db UserDatabase, cache map[string][][]byte) ([]byte, 
 
 	ok, names, locs, _ := m.DerivePath(db)
 	if !ok {
-		return nil, errors.New("Not enough shares to recover.")
+		return nil, ErrNotEnoughShares
 	}
 
 	for _, name := range names {

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -13,9 +13,12 @@ import (
 
 var defaultStore Store = &File{}
 
+// Labels are the labels that the keycache should be encrypted with.
+var Labels = []string{"restore"}
+
 const (
-	// NeverPersist indicates that the persistence store will
-	// never persist active delegations.
+	// Disabled indicates that the persistence store will never
+	// persist active delegations.
 	Disabled = "disabled"
 
 	// Inactive indicates that the persistence store requires
@@ -52,6 +55,7 @@ type Store interface {
 	Cache() *keycache.Cache
 }
 
+// FileMechanism indicates that the persistence mechanism is a file.
 const FileMechanism = "file"
 
 type mechanism func(*config.Delegations) (Store, error)
@@ -61,6 +65,8 @@ var stores = map[string]mechanism{
 	FileMechanism: newFile,
 }
 
+// New attempts to create a new persistence store from the
+// configuration.
 func New(config *config.Delegations) (Store, error) {
 	if config == nil {
 		return nil, errors.New("persist: nil configuration")
@@ -78,4 +84,6 @@ func New(config *config.Delegations) (Store, error) {
 	return constructor(config)
 }
 
+// ErrInvalidConfig is returned when the configuration is invalid for
+// the type of persistence store in use.
 var ErrInvalidConfig = errors.New("persist: invalid configuration")


### PR DESCRIPTION
This PR addresses @jkroll-cf's feedback on the keycache interface.

+ persistLabels moved from cryptor to persist package global.
+ Restore now explicitly checks for the case where there aren't enough shares to return `ErrRestoreDelegations`.
+ The users responsible for restoring the cache are now logged.
