### PR TITLE
Fix the concurrent map write error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ script:
   - go list github.com/cloudflare/redoctober/... | grep -v vendor | xargs go vet
   - ./scripts/validate-html-generation
   - go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -i sh -c {}
+  - go test -race github.com/cloudflare/redoctober/keycache
+  - go test -race github.com/cloudflare/redoctober/cryptor
+  - go test -race github.com/cloudflare/redoctober/core
   - gover . coverprofile.txt
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f coverprofile.txt

--- a/core/core.go
+++ b/core/core.go
@@ -262,7 +262,6 @@ func Init(path string, config *config.Config) error {
 
 	orders = order.NewOrderer(hipchatClient)
 	crypt, err = cryptor.New(&records, nil, config)
-
 	return err
 }
 

--- a/cryptor/cryptor.go
+++ b/cryptor/cryptor.go
@@ -37,7 +37,8 @@ type Cryptor struct {
 
 func New(records *passvault.Records, cache *keycache.Cache, config *config.Config) (*Cryptor, error) {
 	if cache == nil {
-		cache = &keycache.Cache{UserKeys: make(map[keycache.DelegateIndex]keycache.ActiveUser)}
+		c := keycache.NewCache()
+		cache = &c
 	}
 
 	store, err := persist.New(config.Delegations)

--- a/keycache/keycache_test.go
+++ b/keycache/keycache_test.go
@@ -94,7 +94,7 @@ func TestTimeFlush(t *testing.T) {
 
 	cache := NewCache()
 
-	err = cache.AddKeyFromRecord(pr, "user", "weakpassword", nil, nil, 10, "", "1s")
+	err = cache.AddKeyFromRecord(pr, "user", "weakpassword", nil, nil, 10, "", "10s")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -104,7 +104,7 @@ func TestTimeFlush(t *testing.T) {
 		t.Fatalf("Error in number of live keys")
 	}
 
-	time.Sleep(time.Second)
+	time.Sleep(11 * time.Second)
 
 	dummy := make([]byte, 16)
 	pubEncryptedKey, err := pr.EncryptKey(dummy)
@@ -312,7 +312,7 @@ func TestRefresh(t *testing.T) {
 		pr, "user", "weakpassword",
 		[]string{"ci", "buildeng", "user"},
 		[]string{"red", "blue"},
-		1, "", "1s",
+		1, "", "10s",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -323,7 +323,7 @@ func TestRefresh(t *testing.T) {
 		t.Fatalf("Refresh should not have removed any active users.")
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	removed = cache.Refresh()
 	if removed != 1 {


### PR DESCRIPTION
+ Add a lock to the keycache.
+ Ensure that all instantiations of keycaches use New, rather than the old keycache.Cache{make()} construct. This no longer works with the lock in place.
+ Update travis to run the race detector on a few specific packages that should help identify this type of problem in the future. Some of the timeouts have been adjusted to account for the extra time taken by the race detector.
