### PR TITLE
Enable sentry reporting.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,11 @@ type Metrics struct {
 	Port string `json:"port"`
 }
 
+// Reporting contains configuration for error reporting.
+type Reporting struct {
+	SentryDSN string `json:"sentry_dsn"`
+}
+
 // Delegations contains configuration for persisting delegations.
 type Delegations struct {
 	// Persist controls whether delegations are persisted or not.
@@ -100,6 +105,7 @@ type Config struct {
 	UI          *UI          `json:"ui"`
 	HipChat     *HipChat     `json:"hipchat"`
 	Metrics     *Metrics     `json:"metrics"`
+	Reporting   *Reporting   `json:"reporting"`
 	Delegations *Delegations `json:"delegations"`
 }
 
@@ -126,6 +132,7 @@ func New() *Config {
 		UI:          &UI{},
 		HipChat:     &HipChat{},
 		Metrics:     &Metrics{},
+		Reporting:   &Reporting{},
 		Delegations: &Delegations{},
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,6 +62,10 @@ func (m *Metrics) equal(other *Metrics) bool {
 	return m.Host == other.Host && m.Port == other.Port
 }
 
+func (r *Reporting) equal(other *Reporting) bool {
+	return r.SentryDSN == other.SentryDSN
+}
+
 func (d *Delegations) equal(other *Delegations) bool {
 	return d.Persist == other.Persist && d.Policy == other.Policy
 }
@@ -80,6 +84,10 @@ func (c *Config) equal(other *Config) bool {
 	}
 
 	if !c.Metrics.equal(other.Metrics) {
+		return false
+	}
+
+	if !c.Reporting.equal(other.Reporting) {
 		return false
 	}
 

--- a/report/report.go
+++ b/report/report.go
@@ -1,0 +1,78 @@
+// Package report contains error reporting functions.
+package report
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cloudflare/redoctober/config"
+	raven "github.com/getsentry/raven-go"
+)
+
+// sentry will be set to true if sentry reporting is valid.
+var sentry bool
+
+// sentryTags contains additional tags that can be sent to Sentry.
+var sentryTags = map[string]string{}
+
+func configSentry(cfg *config.Config) {
+	raven.SetDSN(cfg.Reporting.SentryDSN)
+	sentry = true
+	sentryTags["started_at"] = fmt.Sprintf("%d", time.Now().Unix())
+
+	sentryTags["server.systemd"] = fmt.Sprintf("%v", cfg.Server.Systemd)
+	if cfg.Server.Addr != "" {
+		sentryTags["server.address"] = cfg.Server.Addr
+	}
+
+	sentryTags["metrics.host"] = cfg.Metrics.Host
+	sentryTags["metrics.port"] = cfg.Metrics.Port
+
+	if cfg.HipChat.ID != "" {
+		sentryTags["hipchat.id"] = cfg.HipChat.ID
+	}
+
+	sentryTags["persist.enabled"] = fmt.Sprintf("%v", cfg.Delegations.Persist)
+	if cfg.Delegations.Persist {
+		sentryTags["persist.mechanism"] = cfg.Delegations.Mechanism
+		sentryTags["persist.location"] = cfg.Delegations.Location
+	}
+}
+
+func Init(cfg *config.Config) {
+	if cfg.Reporting.SentryDSN != "" {
+		configSentry(cfg)
+	}
+}
+
+// Check will see if err contains an error; if it does, and if
+// reporting is configured, it will report the error.
+func Check(err error, tags map[string]string) {
+	if err == nil {
+		return
+	}
+
+	if tags == nil {
+		tags = map[string]string{}
+	}
+
+	if sentry {
+		for k, v := range sentryTags {
+			tags[k] = v
+		}
+		raven.CaptureError(err, tags)
+	}
+}
+
+// Recover will wrap the function in a manner that will capture
+// panics. If error reporting isn't active, it will just panic. This
+// default behaviour allows the stack trace to be capture in the
+// system logs and the service management system (e.g. systemd) to
+// automatically restart the server.
+func Recover(fn func()) {
+	if sentry {
+		raven.CapturePanic(fn, sentryTags)
+	} else {
+		fn()
+	}
+}


### PR DESCRIPTION
This commit adds basic sentry reporting. If enabled by setting the appropriate configuration value, it will report panics and errors. Certain functions in the core package (Delegate, Encrypt, Decrypt, Restore, and ResetPersisted) have additional Sentry reporting as these are the most common errors.