### PR TITLE
[FIX] Add Go dependency clones to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN groupadd -r redoctober --gid=999 && useradd -r -g redoctober --uid=999 redoc
 RUN apt-get update && \
     apt-get install -y openssl runit
 
+# Clone Go dependencies
+RUN git clone https://github.com/getsentry/raven-go.git /go/src/github.com/getsentry/raven-go
+RUN git clone https://github.com/certifi/gocertifi.git /go/src/github.com/certifi/gocertifi
+
 COPY . /go/src/github.com/cloudflare/redoctober
 RUN go install github.com/cloudflare/redoctober
 


### PR DESCRIPTION
It is not currently possible to clone this repo then build with the included Dockerfile due to some missing Go dependencies. 

For some reason, `go get` isn't actually fetching them - maybe something in the base image. Cloning manually as proposed here works though, although it doesn't seem ideal.

Before:
```
runbot@runbot:~$ git clone https://github.com/cloudflare/redoctober
Cloning into 'redoctober'...
remote: Counting objects: 1568, done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 1568 (delta 0), reused 0 (delta 0), pack-reused 1558
Receiving objects: 100% (1568/1568), 866.02 KiB | 0 bytes/s, done.
Resolving deltas: 100% (673/673), done.
Checking connectivity... done.
runbot@runbot:~$ cd redoctober/
runbot@runbot:~/redoctober$ docker build -t redoctober:vanilla .
Sending build context to Docker daemon 2.763 MB
Step 1 : FROM golang:1.7.1
1.7.1: Pulling from library/golang
6a5a5368e0c2: Pull complete 
7b9457ec39de: Pull complete 
ff18e19c2db4: Pull complete 
00075397a1ec: Pull complete 
ee3cf1ce58d6: Pull complete 
741206fcd3b8: Pull complete 
369d69bdd76d: Pull complete 
Digest: sha256:97bb851c6df77ecd9f1b8cfae437829155783828d0de116d82212e9d989acd69
Status: Downloaded newer image for golang:1.7.1
 ---> 47734a1408b7
Step 2 : RUN groupadd -r redoctober --gid=999 && useradd -r -g redoctober --uid=999 redoctober
 ---> Running in 842d39a90eca
 ---> 91aaf01653ad
Removing intermediate container 842d39a90eca
Step 3 : RUN apt-get update &&     apt-get install -y openssl runit
 ---> Running in 026df8a8629c
Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Ign http://httpredir.debian.org jessie InRelease
Get:2 http://httpredir.debian.org jessie-updates InRelease [145 kB]
Get:3 http://security.debian.org jessie/updates/main amd64 Packages [425 kB]
Get:4 http://httpredir.debian.org jessie Release.gpg [2373 B]
Get:5 http://httpredir.debian.org jessie Release [148 kB]
Get:6 http://httpredir.debian.org jessie-updates/main amd64 Packages [17.6 kB]
Get:7 http://httpredir.debian.org jessie/main amd64 Packages [9064 kB]
Fetched 9865 kB in 3s (3213 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  fgetty
Suggested packages:
  socklog-run
The following NEW packages will be installed:
  fgetty runit
The following packages will be upgraded:
  openssl
1 upgraded, 2 newly installed, 0 to remove and 10 not upgraded.
Need to get 807 kB of archives.
After this operation, 520 kB of additional disk space will be used.
Get:1 http://security.debian.org/ jessie/updates/main openssl amd64 1.0.1t-1+deb8u5 [665 kB]
Get:2 http://httpredir.debian.org/debian/ jessie/main fgetty amd64 0.6-5 [25.9 kB]
Get:3 http://httpredir.debian.org/debian/ jessie/main runit amd64 2.1.2-3 [117 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 807 kB in 0s (1128 kB/s)
Selecting previously unselected package fgetty.
(Reading database ... 14767 files and directories currently installed.)
Preparing to unpack .../fgetty_0.6-5_amd64.deb ...
Unpacking fgetty (0.6-5) ...
Preparing to unpack .../openssl_1.0.1t-1+deb8u5_amd64.deb ...
Unpacking openssl (1.0.1t-1+deb8u5) over (1.0.1t-1+deb8u4) ...
Selecting previously unselected package runit.
Preparing to unpack .../runit_2.1.2-3_amd64.deb ...
Unpacking runit (2.1.2-3) ...
Setting up fgetty (0.6-5) ...
Setting up openssl (1.0.1t-1+deb8u5) ...
Setting up runit (2.1.2-3) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
 ---> eee4e3b4d4b6
Removing intermediate container 026df8a8629c
Step 4 : COPY . /go/src/github.com/cloudflare/redoctober
 ---> 205f978d3341
Removing intermediate container 54635db7e597
Step 5 : RUN go install github.com/cloudflare/redoctober
 ---> Running in 3b39e36944e2
src/github.com/cloudflare/redoctober/report/report.go:9:2: cannot find package "github.com/getsentry/raven-go" in any of:
	/go/src/github.com/cloudflare/redoctober/vendor/github.com/getsentry/raven-go (vendor tree)
	/usr/local/go/src/github.com/getsentry/raven-go (from $GOROOT)
	/go/src/github.com/getsentry/raven-go (from $GOPATH)
The command '/bin/sh -c go install github.com/cloudflare/redoctober' returned a non-zero code: 1
```

After this change:
```
runbot@runbot:~/redoctober$ docker build -t redoctober:vanilla .
Sending build context to Docker daemon 2.763 MB
Step 1 : FROM golang:1.7.1
 ---> 47734a1408b7
Step 2 : RUN groupadd -r redoctober --gid=999 && useradd -r -g redoctober --uid=999 redoctober
 ---> Using cache
 ---> 91aaf01653ad
Step 3 : RUN apt-get update &&     apt-get install -y openssl runit
 ---> Using cache
 ---> eee4e3b4d4b6
Step 4 : RUN git clone https://github.com/getsentry/raven-go.git /go/src/github.com/getsentry/raven-go
 ---> Using cache
 ---> da1b5805d7f2
Step 5 : RUN git clone https://github.com/certifi/gocertifi.git /go/src/github.com/certifi/gocertifi
 ---> Running in 1266814cec37
Cloning into '/go/src/github.com/certifi/gocertifi'...
 ---> 4a25f85c1af8
Removing intermediate container 1266814cec37
Step 6 : COPY . /go/src/github.com/cloudflare/redoctober
 ---> a802b8d3e4b0
Removing intermediate container 6773913865e4
Step 7 : RUN go install github.com/cloudflare/redoctober
 ---> Running in 8f138e42a596
 ---> bee0f7030c5f
Removing intermediate container 8f138e42a596
Step 8 : EXPOSE 8080 8081
 ---> Running in 154e6e955f78
 ---> 2731a6eef807
Removing intermediate container 154e6e955f78
Step 9 : ENV RO_CERTS /var/lib/redoctober/data/server.crt RO_KEYS /var/lib/redoctober/data/server.pem RO_DATA /var/lib/redoctober/data RO_CERTPASSWD password RO_COMMONNAME localhost
 ---> Running in 04e3224fccb3
 ---> 43ca23c599e7
Removing intermediate container 04e3224fccb3
Step 10 : ENTRYPOINT /go/src/github.com/cloudflare/redoctober/scripts/docker-entrypoint.sh
 ---> Running in 3debb892976d
 ---> 0825adfe48c1
Removing intermediate container 3debb892976d
Step 11 : CMD redoctober -addr=:8080 -vaultpath=/var/lib/redoctober/data/diskrecord.json -certs=/var/lib/redoctober/data/server.crt -keys=/var/lib/redoctober/data/server.pem
 ---> Running in da08f7d719fc
 ---> ace65d69c44c
Removing intermediate container da08f7d719fc
Successfully built ace65d69c44c
```