### PR TITLE
ro owner command should be robust with base64 encoded RedOctober encr…

### DIFF
--- a/cmd/ro/main.go
+++ b/cmd/ro/main.go
@@ -343,6 +343,12 @@ func runOwner() {
 	inBytes, err := ioutil.ReadFile(inPath)
 	processError(err)
 
+	// attempt to base64 decode the input file
+	base64decoded, err := base64.StdEncoding.DecodeString(string(inBytes))
+	if err == nil {
+		inBytes = base64decoded
+	}
+
 	req := core.OwnersRequest{
 		Data: inBytes,
 	}


### PR DESCRIPTION
…yption.

- We would avoid sending double base64 encoded request to server, triggering cryptic error message