### PR TITLE
Added power support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: go
 go: 1.12
+arch:
+  - AMD64
+  - ppc64le
 script:
   - go get github.com/modocache/gover
   - go get github.com/prometheus/client_golang/...


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.