### PR TITLE
hipchat: fix dropped error

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -48,7 +48,10 @@ func (h *HipchatClient) Notify(msg, color string) error {
 	roomId := url.QueryEscape(strconv.Itoa(h.RoomId))
 	hipchatUrl := fmt.Sprintf("https://%s/v2/room/%s/message?auth_token=%s", h.HcHost, roomId, h.ApiKey)
 	req, err := http.NewRequest("POST", hipchatUrl, bytes.NewReader(body))
-
+	if err != nil {
+		log.Printf("Cannot generate new request for hipchat for the reason %s", err.Error())
+		return err
+	}
 	req.Header.Add("Content-Type", "application/json")
 
 	Client := http.Client{}


### PR DESCRIPTION
This fixes a dropped `err` variable in the `hipchat` package. Unit tests pass both before and after the change.